### PR TITLE
[Feat] 저장된 PlayList를 자세히 보여주는 PlayListDetailView 를 구현합니다.

### DIFF
--- a/PLREQ/PLREQ.xcodeproj/project.pbxproj
+++ b/PLREQ/PLREQ.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A9CD5F828F856E5002E4882 /* PlayListDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9CD5F728F856E5002E4882 /* PlayListDetailCell.swift */; };
 		8B93D54128E8789700AD8170 /* MatchMusicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93D54028E8789700AD8170 /* MatchMusicCell.swift */; };
 		8BFFE1AF28F8412700D183CE /* Struct+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFFE1AE28F8412700D183CE /* Struct+.swift */; };
 		D50F95D628F59C9F0072CDB5 /* NSManagedObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50F95D528F59C9F0072CDB5 /* NSManagedObject+.swift */; };
@@ -46,6 +47,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0A9CD5F728F856E5002E4882 /* PlayListDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayListDetailCell.swift; sourceTree = "<group>"; };
 		8B93D54028E8789700AD8170 /* MatchMusicCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchMusicCell.swift; sourceTree = "<group>"; };
 		8BFFE1AE28F8412700D183CE /* Struct+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Struct+.swift"; sourceTree = "<group>"; };
 		D50F95D528F59C9F0072CDB5 /* NSManagedObject+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+.swift"; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 			children = (
 				D580699D28E45C7500461CD8 /* PlayListDetailView.storyboard */,
 				D580699E28E45C7500461CD8 /* PlayListDetailViewController.swift */,
+				0A9CD5F728F856E5002E4882 /* PlayListDetailCell.swift */,
 			);
 			path = PlayListDetailView;
 			sourceTree = "<group>";
@@ -338,6 +341,7 @@
 				D593996128EF55710082A3F9 /* UILable+.swift in Sources */,
 				D50F95E528F6EA930072CDB5 /* Protocol+.swift in Sources */,
 				D5B9ADA328EAFC5000859D50 /* PlacePlayListViewController.swift in Sources */,
+				0A9CD5F828F856E5002E4882 /* PlayListDetailCell.swift in Sources */,
 				D580697E28E45BF600461CD8 /* CALayer+.swift in Sources */,
 				D5B9ADA028EAFC1800859D50 /* RecentPlayListViewController.swift in Sources */,
 				D537200F28F4A50200753C36 /* PLREQDataManager.swift in Sources */,
@@ -503,7 +507,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
+				DEVELOPMENT_TEAM = HD34Q2YK79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음악을 매칭하기 위하여 마이크에 대한 접근권한이 필요합니다.";
@@ -532,7 +536,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
+				DEVELOPMENT_TEAM = HD34Q2YK79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음악을 매칭하기 위하여 마이크에 대한 접근권한이 필요합니다.";

--- a/PLREQ/PLREQ.xcodeproj/project.pbxproj
+++ b/PLREQ/PLREQ.xcodeproj/project.pbxproj
@@ -511,6 +511,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음악을 매칭하기 위하여 마이크에 대한 접근권한이 필요합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Use your photo album.\nUse your photo album.\nUse your photo album.\nUse user's photo album.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -540,6 +541,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음악을 매칭하기 위하여 마이크에 대한 접근권한이 필요합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Use your photo album.\nUse your photo album.\nUse your photo album.\nUse user's photo album.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -125,7 +125,7 @@ class MatchViewController: UIViewController {
             let thirdImageURL = self.recordedMusicList[2].musicImageURL
             let fourthImageURL = self.recordedMusicList[3].musicImageURL
 
-            PLREQDataManager.shared.save(title: title, location: "", latitude: 0.0, longtitude: 0.0, firstImageURL: firstImageURL, secondImageURL: secondImageURL, thirdImageURL: thirdImageURL, fourthImageURL: fourthImageURL, musics: self.recordedMusicList)
+            PLREQDataManager.shared.save(title: title, location: "", day: Date(), latitude: 0.0, longtitude: 0.0, firstImageURL: firstImageURL, secondImageURL: secondImageURL, thirdImageURL: thirdImageURL, fourthImageURL: fourthImageURL, musics: self.recordedMusicList)
             
             self.recordedMusicList = [Music]()
             self.matchMusicCollectionView.reloadData()

--- a/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailCell.swift
+++ b/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailCell.swift
@@ -1,0 +1,23 @@
+//
+//  PlayListDetailCell.swift
+//  PLREQ
+//
+//  Created by 이성노 on 2022/10/13.
+//
+
+import UIKit
+
+final class PlayListDetailCell: UITableViewCell {
+    
+    @IBOutlet weak var musicImage: UIImageView!
+    @IBOutlet weak var musicTitle: UILabel!
+    @IBOutlet weak var musicArtist: UILabel!
+    
+    override class func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+}

--- a/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailView.storyboard
+++ b/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailView.storyboard
@@ -36,19 +36,19 @@
                                             <action selector="shareButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="FXE-FJ-vfJ"/>
                                         </connections>
                                     </button>
-                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="1O5-z6-Zks">
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="1O5-z6-Zks">
                                         <rect key="frame" x="16" y="180" width="358" height="664"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="playListDetailCell" id="KE9-hg-cyN" customClass="PlayListDetailCell" customModule="PLREQ" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="50" width="358" height="70.333335876464844"/>
+                                                <rect key="frame" x="0.0" y="50" width="358" height="70"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="KE9-hg-cyN" id="tmc-Z4-dRj">
-                                                    <rect key="frame" x="0.0" y="0.0" width="358" height="70.333335876464844"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="358" height="70"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Sj2-0Z-mBi">
-                                                            <rect key="frame" x="10" y="10.000000000000004" width="50" height="50.333333333333343"/>
+                                                            <rect key="frame" x="10" y="10" width="50" height="50"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="50" id="W0Q-y2-cpi"/>
                                                                 <constraint firstAttribute="height" constant="50" id="ca3-rV-1cB"/>

--- a/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailView.storyboard
+++ b/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailView.storyboard
@@ -16,9 +16,105 @@
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IuX-DW-BhG">
+                                <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yV0-HQ-kx8">
+                                        <rect key="frame" x="90" y="110" width="210" height="50"/>
+                                        <color key="backgroundColor" red="0.14117647058823529" green="0.14117647058823529" blue="0.14117647058823529" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="XbT-jy-HBj"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="스크린샷 하기">
+                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="shareButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="FXE-FJ-vfJ"/>
+                                        </connections>
+                                    </button>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="1O5-z6-Zks">
+                                        <rect key="frame" x="16" y="180" width="358" height="664"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <prototypes>
+                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="playListDetailCell" id="KE9-hg-cyN" customClass="PlayListDetailCell" customModule="PLREQ" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="50" width="358" height="70.333335876464844"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="KE9-hg-cyN" id="tmc-Z4-dRj">
+                                                    <rect key="frame" x="0.0" y="0.0" width="358" height="70.333335876464844"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Sj2-0Z-mBi">
+                                                            <rect key="frame" x="10" y="10.000000000000004" width="50" height="50.333333333333343"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="50" id="W0Q-y2-cpi"/>
+                                                                <constraint firstAttribute="height" constant="50" id="ca3-rV-1cB"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="xA0-bk-dqB">
+                                                            <rect key="frame" x="80" y="18.000000000000004" width="35.333333333333343" height="34.333333333333343"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l7G-Jd-DPW">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="35.333333333333336" height="17"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6MY-2P-s8n">
+                                                                    <rect key="frame" x="0.0" y="20" width="35.333333333333336" height="14.333333333333336"/>
+                                                                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="12"/>
+                                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="Sj2-0Z-mBi" firstAttribute="leading" secondItem="tmc-Z4-dRj" secondAttribute="leading" constant="10" id="GF8-kH-lop"/>
+                                                        <constraint firstItem="Sj2-0Z-mBi" firstAttribute="top" secondItem="tmc-Z4-dRj" secondAttribute="top" constant="10" id="Jhz-lE-X8m"/>
+                                                        <constraint firstAttribute="bottom" secondItem="Sj2-0Z-mBi" secondAttribute="bottom" constant="10" id="NKO-zK-n3n"/>
+                                                        <constraint firstItem="xA0-bk-dqB" firstAttribute="centerY" secondItem="Sj2-0Z-mBi" secondAttribute="centerY" id="O0v-Gt-uP7"/>
+                                                        <constraint firstItem="xA0-bk-dqB" firstAttribute="leading" secondItem="Sj2-0Z-mBi" secondAttribute="trailing" constant="20" id="p5P-5c-rPM"/>
+                                                    </constraints>
+                                                </tableViewCellContentView>
+                                                <connections>
+                                                    <outlet property="musicArtist" destination="6MY-2P-s8n" id="z4g-F8-Jej"/>
+                                                    <outlet property="musicImage" destination="Sj2-0Z-mBi" id="ouX-5X-oEv"/>
+                                                    <outlet property="musicTitle" destination="l7G-Jd-DPW" id="24W-wQ-FwU"/>
+                                                </connections>
+                                            </tableViewCell>
+                                        </prototypes>
+                                    </tableView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="yV0-HQ-kx8" secondAttribute="trailing" constant="90" id="4xA-Nk-z8V"/>
+                                    <constraint firstItem="yV0-HQ-kx8" firstAttribute="top" secondItem="IuX-DW-BhG" secondAttribute="top" constant="110" id="RJe-wq-WO0"/>
+                                    <constraint firstItem="1O5-z6-Zks" firstAttribute="leading" secondItem="IuX-DW-BhG" secondAttribute="leading" constant="16" id="UZl-Rq-Z54"/>
+                                    <constraint firstAttribute="bottom" secondItem="1O5-z6-Zks" secondAttribute="bottom" id="VvS-1Z-4R1"/>
+                                    <constraint firstItem="yV0-HQ-kx8" firstAttribute="centerX" secondItem="IuX-DW-BhG" secondAttribute="centerX" id="aXU-Bk-nHy"/>
+                                    <constraint firstItem="1O5-z6-Zks" firstAttribute="top" secondItem="yV0-HQ-kx8" secondAttribute="bottom" constant="20" id="o5n-Nt-yK1"/>
+                                    <constraint firstAttribute="trailing" secondItem="1O5-z6-Zks" secondAttribute="trailing" constant="16" id="pt4-nw-7KJ"/>
+                                    <constraint firstItem="yV0-HQ-kx8" firstAttribute="leading" secondItem="IuX-DW-BhG" secondAttribute="leading" constant="90" id="sG9-eC-wjU"/>
+                                </constraints>
+                            </view>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="IuX-DW-BhG" secondAttribute="trailing" id="90C-aj-jIu"/>
+                            <constraint firstItem="IuX-DW-BhG" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="OJC-cp-HkJ"/>
+                            <constraint firstAttribute="bottom" secondItem="IuX-DW-BhG" secondAttribute="bottom" id="hAf-v3-fIn"/>
+                            <constraint firstItem="IuX-DW-BhG" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="z5i-ZN-BKe"/>
+                        </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="YhS-nC-TlV"/>
+                    <connections>
+                        <outlet property="musicDetailTableView" destination="1O5-z6-Zks" id="S55-mm-eP3"/>
+                        <outlet property="shareButtonTapped" destination="yV0-HQ-kx8" id="7kb-Nj-XWh"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailView.storyboard
+++ b/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailView.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -87,6 +88,24 @@
                                             </tableViewCell>
                                         </prototypes>
                                     </tableView>
+                                    <navigationBar contentMode="scaleToFill" fixedFrame="YES" barStyle="black" translatesAutoresizingMaskIntoConstraints="NO" id="B7Z-in-5CK">
+                                        <rect key="frame" x="0.0" y="55" width="390" height="44"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                        <items>
+                                            <navigationItem title="Title" id="Aba-HS-thO">
+                                                <barButtonItem key="leftBarButtonItem" title="Item" id="zSj-cQ-Vg7">
+                                                    <imageReference key="image" image="chevron.backward" catalog="system" symbolScale="large"/>
+                                                    <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <connections>
+                                                        <action selector="goToBackButton:" destination="Y6W-OH-hqX" id="l14-A9-4Zv"/>
+                                                    </connections>
+                                                </barButtonItem>
+                                            </navigationItem>
+                                        </items>
+                                        <navigationBarAppearance key="standardAppearance">
+                                            <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </navigationBarAppearance>
+                                    </navigationBar>
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
@@ -110,9 +129,10 @@
                             <constraint firstItem="IuX-DW-BhG" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="z5i-ZN-BKe"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="YhS-nC-TlV"/>
                     <connections>
                         <outlet property="musicDetailTableView" destination="1O5-z6-Zks" id="S55-mm-eP3"/>
+                        <outlet property="navigationBar" destination="B7Z-in-5CK" id="aLa-uv-Jkq"/>
+                        <outlet property="navigationTitle" destination="Aba-HS-thO" id="xqG-jH-95S"/>
                         <outlet property="shareButtonTapped" destination="yV0-HQ-kx8" id="7kb-Nj-XWh"/>
                     </connections>
                 </viewController>
@@ -122,6 +142,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="chevron.backward" catalog="system" width="97" height="128"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
@@ -7,7 +7,11 @@
 
 import UIKit
 
-class PlayListDetailViewController: UIViewController {
+final class PlayListDetailViewController: UIViewController {
+    
+    @IBOutlet weak var shareButtonTapped: UIButton!
+    @IBOutlet weak var musicDetailTableView: UITableView!
+    
     var playList: PlayListDB!
     var musicList: [MusicDB]! {
         return playList.music?.array as? [MusicDB]
@@ -16,17 +20,33 @@ class PlayListDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // Do any additional setup after loading the view.
+        musicDetailTableView.delegate = self
+        musicDetailTableView.dataSource = self
+        
+        shareButtonTapped.layer.cornerRadius = shareButtonTapped.frame.height / 2
     }
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    @IBAction func shareButtonTapped(_ sender: Any) {
+        print("되나?")
     }
-    */
+}
 
+extension PlayListDetailViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return musicList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "playListDetailCell", for: indexPath) as? PlayListDetailCell
+        
+        let musicData = musicList[indexPath.row]
+        cell?.musicImage.load(url: musicData.dataToURL(forKey: "musicImageURL"))
+        cell?.musicImage.layer.cornerRadius = 6
+//        view.layer.cornerRadius = Constant.thumbnailSize / 2.0
+
+        cell?.musicTitle.text = musicData.dataToString(forKey: "title")
+        cell?.musicArtist.text = musicData.dataToString(forKey: "artist")
+        
+        return cell ?? UITableViewCell()
+    }
 }

--- a/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
@@ -9,6 +9,9 @@ import UIKit
 
 final class PlayListDetailViewController: UIViewController {
     
+    @IBOutlet weak var navigationBar: UINavigationBar!
+    @IBOutlet weak var navigationTitle: UINavigationItem!
+    
     @IBOutlet weak var shareButtonTapped: UIButton!
     @IBOutlet weak var musicDetailTableView: UITableView!
     
@@ -17,21 +20,32 @@ final class PlayListDetailViewController: UIViewController {
         return playList.music?.array as? [MusicDB]
     }
     
+    var navigationTitleText: String! {
+        return "\(playList.dataToString(forKey: "title"))"
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        musicDetailTableView.delegate = self
+        setupNavigationController()
+        navigationTitle.title = navigationTitleText
+        
         musicDetailTableView.dataSource = self
         
         shareButtonTapped.layer.cornerRadius = shareButtonTapped.frame.height / 2
     }
 
+    @IBAction func goToBackButton(_ sender: Any) {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
     @IBAction func shareButtonTapped(_ sender: Any) {
-        print("되나?")
+        print("Is it sellected?")
     }
 }
 
-extension PlayListDetailViewController: UITableViewDataSource, UITableViewDelegate {
+extension PlayListDetailViewController: UITableViewDataSource {
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return musicList.count
     }
@@ -42,11 +56,20 @@ extension PlayListDetailViewController: UITableViewDataSource, UITableViewDelega
         let musicData = musicList[indexPath.row]
         cell?.musicImage.load(url: musicData.dataToURL(forKey: "musicImageURL"))
         cell?.musicImage.layer.cornerRadius = 6
-//        view.layer.cornerRadius = Constant.thumbnailSize / 2.0
 
         cell?.musicTitle.text = musicData.dataToString(forKey: "title")
         cell?.musicArtist.text = musicData.dataToString(forKey: "artist")
         
         return cell ?? UITableViewCell()
+    }
+}
+
+private extension PlayListDetailViewController {
+    
+    func setupNavigationController() {
+        self.navigationBar.translatesAutoresizingMaskIntoConstraints = false
+        self.navigationBar.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor).isActive = true
+        self.navigationBar.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 0).isActive = true
+        self.navigationBar.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: 0).isActive = true
     }
 }


### PR DESCRIPTION
@Juhwa-Lee1023 
@2youngjun 
@yeniful 

---

안녕하세요 코인, 준, 예니! 드디어 제가 작업을 시작하게 됐네요 😎 너무 고생 많으셨습니다!
코인과 준이 만들어주신 `PlayList` 를 받아와 작업을 시작했어요. 코인(@Juhwa-Lee1023)이 만들어주신 Extension 정말 잘 사용했어요. 너무 감사합니다!

작업을 진행하며 개선해야 할 점과 작업 내용을 아래에 정리해봤어요! 확인 부탁드립니다!  👀..

---

### OutLine
- #22 

### Work Contents
- `PlayList` 의 DB 정보를 나타내는 `PlayListDetailView` 를 구현했습니다.
- `PlayList` 의 제목 데이터를 받아와 `PlayListDetailView` 의 네비게이션 타이틀에 보여줍니다.
- 좀 더 개선된 UI를 위해 디자인을 개선했습니다.

### App Action Screen
https://user-images.githubusercontent.com/78950704/195693131-c89af451-86fb-4705-b368-03cecba2b936.mov

### Review Note

<img width="30%" src="https://user-images.githubusercontent.com/78950704/195693819-ea806ad8-b75f-43b2-9243-21e1c416bada.png"/>

- 올바르지 않은 데이터 값(에러 값)을 받아왔을 때, 정형화 된 데이터 구현이 필요할 것 같아요! 추후에 같이 논의해봐요 🤓
  - (앨범 커버의 이미지는 뭐로 할 지, 아티스트와 제목의 값은 뭐로 할 지..)


---