### PR TITLE
[Feat] #25 playlist 애플 뮤직으로 내보내기 구현

### DIFF
--- a/PLREQ/PLREQ.xcodeproj/project.pbxproj
+++ b/PLREQ/PLREQ.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		8B93D54128E8789700AD8170 /* MatchMusicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93D54028E8789700AD8170 /* MatchMusicCell.swift */; };
 		8BFFE1AF28F8412700D183CE /* Struct+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFFE1AE28F8412700D183CE /* Struct+.swift */; };
 		A8DBF62128F83D4000A01C47 /* MapAnnotationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8DBF62028F83D4000A01C47 /* MapAnnotationViewController.swift */; };
+		D50154BD28F9D38E001BA8D5 /* Notification.Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50154BC28F9D38E001BA8D5 /* Notification.Name+.swift */; };
 		D50F95D628F59C9F0072CDB5 /* NSManagedObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50F95D528F59C9F0072CDB5 /* NSManagedObject+.swift */; };
 		D50F95DC28F5DDE40072CDB5 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50F95DB28F5DDE40072CDB5 /* UINavigationController+.swift */; };
 		D50F95E528F6EA930072CDB5 /* Protocol+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50F95E428F6EA930072CDB5 /* Protocol+.swift */; };
@@ -53,6 +54,7 @@
 		8B93D54028E8789700AD8170 /* MatchMusicCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchMusicCell.swift; sourceTree = "<group>"; };
 		8BFFE1AE28F8412700D183CE /* Struct+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Struct+.swift"; sourceTree = "<group>"; };
 		A8DBF62028F83D4000A01C47 /* MapAnnotationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapAnnotationViewController.swift; sourceTree = "<group>"; };
+		D50154BC28F9D38E001BA8D5 /* Notification.Name+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+.swift"; sourceTree = "<group>"; };
 		D50F95D528F59C9F0072CDB5 /* NSManagedObject+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+.swift"; sourceTree = "<group>"; };
 		D50F95DB28F5DDE40072CDB5 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		D50F95E428F6EA930072CDB5 /* Protocol+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Protocol+.swift"; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 				D593996228EF59B30082A3F9 /* Date+.swift */,
 				D50F95D528F59C9F0072CDB5 /* NSManagedObject+.swift */,
 				D50F95DB28F5DDE40072CDB5 /* UINavigationController+.swift */,
+				D50154BC28F9D38E001BA8D5 /* Notification.Name+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 				A8DBF62128F83D4000A01C47 /* MapAnnotationViewController.swift in Sources */,
 				D537201428F4A81A00753C36 /* PlayListDB+CoreDataClass.swift in Sources */,
 				D50F960828F724BC0072CDB5 /* AppleMusicExport.swift in Sources */,
+				D50154BD28F9D38E001BA8D5 /* Notification.Name+.swift in Sources */,
 				D593996128EF55710082A3F9 /* UILable+.swift in Sources */,
 				D50F95E528F6EA930072CDB5 /* Protocol+.swift in Sources */,
 				D5B9ADA328EAFC5000859D50 /* PlacePlayListViewController.swift in Sources */,

--- a/PLREQ/PLREQ/Extensions/Notification.Name+.swift
+++ b/PLREQ/PLREQ/Extensions/Notification.Name+.swift
@@ -1,0 +1,12 @@
+//
+//  Notification.Name+.swift
+//  PLREQ
+//
+//  Created by 이주화 on 2022/10/15.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let viewReload = Notification.Name("viewReload")
+}

--- a/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
+++ b/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
@@ -49,12 +49,10 @@ final class AppleMusicExport: MusicPlaylistAddable, Sendable {
         Task {
             let request = MusicLibrarySearchRequest(term: name, types: [Playlist.self])
             let libraryResponse = try await request.response()
-            print("❤️")
             if !libraryResponse.playlists.isEmpty { // 입력하려고하는 플레이리스트의 이름이 있는지 확인
                 Task {
                     musicList.forEach() { musicTitle in
                         Task {
-                            print("❤️")
                             var request = MusicCatalogSearchRequest.init(term: musicTitle, types: [Song.self])
                             request.includeTopResults = true
                             let response = try await request.response()
@@ -64,11 +62,9 @@ final class AppleMusicExport: MusicPlaylistAddable, Sendable {
                 }
             } else {
                 Task {
-                    print("❤️")
                     let newPlayList = try await MusicLibrary.shared.createPlaylist(name: name, description: "PLREQ에서 생성된 플레이리스트 입니다.", authorDisplayName: "PLREQ")
                     musicList.forEach() { musicTitle in
                         Task {
-                            print("❤️")
                             var request = MusicCatalogSearchRequest.init(term: musicTitle, types: [Song.self])
                             request.includeTopResults = true
                             let reponse = try await request.response()

--- a/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
+++ b/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
@@ -36,7 +36,9 @@ final class AppleMusicExport: MusicPlaylistAddable, Sendable {
                     var request = MusicCatalogSearchRequest.init(term: musicTitle, types: [Song.self])
                     request.includeTopResults = true
                     let reponse = try await request.response()
-                    try await MusicLibrary.shared.add(reponse.songs.first!, to: newPlayList)
+                    if !reponse.songs.isEmpty { // 검색한 노래가 있는지 화기인
+                        try await MusicLibrary.shared.add(reponse.songs.first!, to: newPlayList)
+                    }
                 }
             }
         }
@@ -46,14 +48,34 @@ final class AppleMusicExport: MusicPlaylistAddable, Sendable {
     func addSongsToPlayList(name: String, musicList: [String]) {
         Task {
             let request = MusicLibrarySearchRequest(term: name, types: [Playlist.self])
-            let response = try await request.response()
-            Task {
-                musicList.forEach() { musicTitle in
-                    Task {
-                        var request = MusicCatalogSearchRequest.init(term: musicTitle, types: [Song.self])
-                        request.includeTopResults = true
-                        let reponse = try await request.response()
-                        try await MusicLibrary.shared.add(reponse.songs.first!, to: response.playlists[0])
+            let libraryResponse = try await request.response()
+            print("❤️")
+            if !libraryResponse.playlists.isEmpty { // 입력하려고하는 플레이리스트의 이름이 있는지 확인
+                Task {
+                    musicList.forEach() { musicTitle in
+                        Task {
+                            print("❤️")
+                            var request = MusicCatalogSearchRequest.init(term: musicTitle, types: [Song.self])
+                            request.includeTopResults = true
+                            let response = try await request.response()
+                            try await MusicLibrary.shared.add(response.songs.first!, to: libraryResponse.playlists[0])
+                        }
+                    }
+                }
+            } else {
+                Task {
+                    print("❤️")
+                    let newPlayList = try await MusicLibrary.shared.createPlaylist(name: name, description: "PLREQ에서 생성된 플레이리스트 입니다.", authorDisplayName: "PLREQ")
+                    musicList.forEach() { musicTitle in
+                        Task {
+                            print("❤️")
+                            var request = MusicCatalogSearchRequest.init(term: musicTitle, types: [Song.self])
+                            request.includeTopResults = true
+                            let reponse = try await request.response()
+                            if !reponse.songs.isEmpty { // 검색한 노래가 있는지 화기인
+                                try await MusicLibrary.shared.add(reponse.songs.first!, to: newPlayList)
+                            }
+                        }
                     }
                 }
             }

--- a/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListViewController.swift
@@ -16,13 +16,21 @@ class PlacePlayListViewController: UIViewController {
     
     var playListList: [NSManagedObject] = []
     var placeList: [String] = []
+    var delegate: viewChangeButtonClick?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         registerNib()
         tableViewLink()
         setAutoLayout()
+        NotificationCenter.default.addObserver(self, selector: #selector(reloadView), name: .viewReload, object: nil)
         // Do any additional setup after loading the view.
+    }
+
+    @objc func reloadView(_ noti: Notification) {
+        self.playListList = PLREQDataManager.shared.fetch()
+        self.placeList.removeAll()
+        self.PlacePlayListTableView.reloadData()
     }
     
     private func registerNib() {
@@ -111,7 +119,8 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
             let deleteAlert = UIAlertController(title: "\(self.playListList[indexPath].dataToString(forKey: "title"))를 정말 삭제하시겠어요?", message: "삭제하면 되돌릴 수 없어요!", preferredStyle: .alert)
             let deleteCancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
             let deletePlayList = UIAlertAction(title: "플레이리스트 삭제", style: .destructive) { _ in
-                let check = PLREQDataManager.shared.delete(playListObject: self.playListList[indexPath])
+                _ = PLREQDataManager.shared.delete(playListObject: self.playListList[indexPath])
+                self.playListList = PLREQDataManager.shared.fetch()
                 self.placeList.removeAll()
                 self.PlacePlayListTableView.reloadData()
             }
@@ -120,38 +129,77 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
             self.present(deleteAlert, animated: true, completion: nil)
         }
         let apple = UIAlertAction(title: "애플뮤직으로 내보내기", style: .default) { _ in
-            
-        }
-        let appleName = UIAlertAction(title: "애플뮤직 기존 플레이리스트에 추가하기", style: .default) { _ in
-            let appleAlert = UIAlertController(title: "이름을 입력해주세요.", message: nil, preferredStyle: .alert)
-            let registerButton = UIAlertAction(title: "저장", style: .default, handler: { _ in
+            if #available(iOS 16.0, *) {
+                let appleAlert = UIAlertController(title: "정말 내보내시겠어요?", message: "'\(self.playListList[indexPath].dataToString(forKey: "title"))'으로 저장됩니다.", preferredStyle: .alert)
+                let appleCancel = UIAlertAction(title: "취소", style: .destructive, handler: nil)
+                let addPlayList = UIAlertAction(title: "플레이리스트 내보내기", style: .default) { _ in
+                    let musicLists = (self.playListList[indexPath] as! PlayListDB).music?.array as? [MusicDB]
+                    var musicListsTitle: [String] = []
+                    for i in 0..<musicLists!.count {
+                        musicListsTitle.append("")
+                        musicListsTitle[i] = musicListsTitle[i] + musicLists![i].dataToString(forKey: "artist") + " " + musicLists![i].dataToString(forKey: "title")
+                    }
+                    AppleMusicExport().addPlayList(name: self.playListList[indexPath].dataToString(forKey: "title"), musicList: musicListsTitle)
+                }
+                appleAlert.addAction(addPlayList)
+                appleAlert.addAction(appleCancel)
                 
+                self.present(appleAlert, animated: true, completion: nil)
+            } else {
+                let appleAlert = UIAlertController(title: "애플 뮤직 관련 기능을 사용하실려면 iOS 16버전 이상의 버전이 필요합니다.", message: "사용하시려면 iOS 버전을 확인해주세요.", preferredStyle: .alert)
+                let appleCancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+                appleAlert.addAction(appleCancel)
+                self.present(appleAlert, animated: true, completion: nil)
+            }
+        }
+        
+        let appleName = UIAlertAction(title: "애플뮤직 특정 플레이리스트에 추가하기", style: .default) { _ in
+            let appleNameAlert = UIAlertController(title: "이름을 입력해주세요.\n(일치하는 플레이리스트가 없다면 입력한 이름으로 저장됩니다.)", message: nil, preferredStyle: .alert)
+            let registerButton = UIAlertAction(title: "저장", style: .default, handler: { _ in
+                if #available(iOS 16.0, *) {
+                    guard var playlistTitle = appleNameAlert.textFields?[0].text else { return }
+                    if((playlistTitle == "")) { playlistTitle = self.playListList[indexPath].dataToString(forKey: "title") }
+                    let musicLists = (self.playListList[indexPath] as! PlayListDB).music?.array as? [MusicDB]
+                    var musicListsTitle: [String] = []
+                    for i in 0..<musicLists!.count {
+                        musicListsTitle.append("")
+                        musicListsTitle[i] = musicListsTitle[i] + musicLists![i].dataToString(forKey: "artist") + " " + musicLists![i].dataToString(forKey: "title")
+                    }
+                    AppleMusicExport().addSongsToPlayList(name: playlistTitle, musicList: musicListsTitle)
+                    appleNameAlert.dismiss(animated: true)
+                } else {
+                    let appleAlert = UIAlertController(title: "애플 뮤직 관련 기능을 사용하실려면 iOS 16버전 이상의 버전이 필요합니다.", message: "사용하시려면 iOS 버전을 확인해주세요.", preferredStyle: .alert)
+                    let appleCancel = UIAlertAction(title: "확인", style: .cancel, handler: nil)
+                    appleAlert.addAction(appleCancel)
+                    self.present(appleAlert, animated: true, completion: nil)
+                }
             })
-            let cancelButton = UIAlertAction(title: "취소", style: .cancel, handler: { _ in
-                appleAlert.dismiss(animated: true)
-            })
-              
-            appleAlert.addAction(cancelButton)
-            appleAlert.addAction(registerButton)
-            appleAlert.addTextField(configurationHandler: { textField in
-                textField.placeholder = "PLREQ"
+            let cancelButton = UIAlertAction(title: "취소", style: .destructive, handler: { _ in
+                appleNameAlert.dismiss(animated: true)
             })
             
-            self.present(appleAlert, animated: true)
+            appleNameAlert.addAction(cancelButton)
+            appleNameAlert.addAction(registerButton)
+            appleNameAlert.addTextField(configurationHandler: { textField in
+                textField.placeholder = self.playListList[indexPath].dataToString(forKey: "title")
+            })
+            
+            self.present(appleNameAlert, animated: true)
         }
-        let changeTitle = UIAlertAction(title: "플레이 이름 변경하기", style: .default) { _ in
+        let changeTitle = UIAlertAction(title: "플레이리스트 이름 변경하기", style: .default) { _ in
             let changeAlert = UIAlertController(title: "이름을 입력해주세요.", message: nil, preferredStyle: .alert)
             let registerButton = UIAlertAction(title: "저장", style: .default, handler: { _ in
-                guard let title = changeAlert.textFields?[0].text else { return }
-                PLREQDataManager.shared.updateTitle(playListObject: self.playListList[indexPath], title: title)
+                guard var title = changeAlert.textFields?[0].text else { return }
+                if(title == "") { title = "PLREQ" }
+                _ = PLREQDataManager.shared.updateTitle(playListObject: self.playListList[indexPath], title: title)
                 self.playListList = PLREQDataManager.shared.fetch()
                 self.placeList.removeAll()
                 self.PlacePlayListTableView.reloadData()
             })
-            let cancelButton = UIAlertAction(title: "취소", style: .cancel, handler: { _ in
+            let cancelButton = UIAlertAction(title: "취소", style: .destructive, handler: { _ in
                 changeAlert.dismiss(animated: true)
             })
-              
+            
             changeAlert.addAction(cancelButton)
             changeAlert.addAction(registerButton)
             changeAlert.addTextField(configurationHandler: { textField in
@@ -160,6 +208,7 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
             
             self.present(changeAlert, animated: true)
         }
+        
         
         let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         alret.addAction(cancel)
@@ -177,3 +226,4 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
         self.navigationController?.pushViewController(playListDetailViewController, animated: true)
     }
     
+}

--- a/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListViewController.swift
@@ -16,7 +16,6 @@ class PlacePlayListViewController: UIViewController {
     
     var playListList: [NSManagedObject] = []
     var placeList: [String] = []
-    var delegate: viewChangeButtonClick?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -128,6 +127,7 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
             deleteAlert.addAction(deletePlayList)
             self.present(deleteAlert, animated: true, completion: nil)
         }
+        
         let apple = UIAlertAction(title: "애플뮤직으로 내보내기", style: .default) { _ in
             if #available(iOS 16.0, *) {
                 let appleAlert = UIAlertController(title: "정말 내보내시겠어요?", message: "'\(self.playListList[indexPath].dataToString(forKey: "title"))'으로 저장됩니다.", preferredStyle: .alert)
@@ -186,6 +186,7 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
             
             self.present(appleNameAlert, animated: true)
         }
+        
         let changeTitle = UIAlertAction(title: "플레이리스트 이름 변경하기", style: .default) { _ in
             let changeAlert = UIAlertController(title: "이름을 입력해주세요.", message: nil, preferredStyle: .alert)
             let registerButton = UIAlertAction(title: "저장", style: .default, handler: { _ in
@@ -208,7 +209,6 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
             
             self.present(changeAlert, animated: true)
         }
-        
         
         let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         alret.addAction(cancel)

--- a/PLREQ/PLREQ/Views/PlayListView/PlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlayListViewController.swift
@@ -63,7 +63,7 @@ class PlayListViewController: UIViewController {
         self.navigationController?.pushViewController(mapViewViewController, animated: true)
     }
     
-    @IBAction func selecButton(_ sender: UIButton) {
+    @IBAction func selectButton(_ sender: UIButton) {
         if sender.titleLabel?.text == "최근" {
             NotificationCenter.default.post(name: .viewReload, object: nil)
             RecentPlayListContainerView.isHidden = false

--- a/PLREQ/PLREQ/Views/PlayListView/PlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlayListViewController.swift
@@ -65,6 +65,7 @@ class PlayListViewController: UIViewController {
     
     @IBAction func selecButton(_ sender: UIButton) {
         if sender.titleLabel?.text == "최근" {
+            NotificationCenter.default.post(name: .viewReload, object: nil)
             RecentPlayListContainerView.isHidden = false
             PlacePlayListContainerView.isHidden = true
             recentButton.layer.addBorder([.bottom], color: .white, width: 2)
@@ -74,6 +75,7 @@ class PlayListViewController: UIViewController {
             }
             buttonCheck = false
         } else {
+            NotificationCenter.default.post(name: .viewReload, object: nil)
             RecentPlayListContainerView.isHidden = true
             PlacePlayListContainerView.isHidden = false
             placeButton.layer.addBorder([.bottom], color: .white, width: 2)
@@ -104,14 +106,4 @@ class PlayListViewController: UIViewController {
         playListButtonStackView.layer.addBorder([.bottom], color: .gray, width: 1)
         
     }
-    /*
-     // MARK: - Navigation
-     
-     // In a storyboard-based application, you will often want to do a little preparation before navigation
-     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-     // Get the new view controller using segue.destination.
-     // Pass the selected object to the new view controller.
-     }
-     */
-    
 }

--- a/PLREQ/PLREQ/Views/PlayListView/RecentPlayListView/RecentPlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/RecentPlayListView/RecentPlayListViewController.swift
@@ -128,6 +128,7 @@ extension RecentPlayListViewController: collectionViewCelEditButtonlClicked {
             deleteAlert.addAction(deletePlayList)
             self.present(deleteAlert, animated: true, completion: nil)
         }
+        
         let apple = UIAlertAction(title: "애플뮤직으로 내보내기", style: .default) { _ in
             if #available(iOS 16.0, *) {
                 let appleAlert = UIAlertController(title: "정말 내보내시겠어요?", message: "'\(self.playListList[indexPath].dataToString(forKey: "title"))'으로 저장됩니다.", preferredStyle: .alert)
@@ -185,6 +186,7 @@ extension RecentPlayListViewController: collectionViewCelEditButtonlClicked {
             
             self.present(appleNameAlert, animated: true)
         }
+        
         let changeTitle = UIAlertAction(title: "플레이리스트 이름 변경하기", style: .default) { _ in
             let changeAlert = UIAlertController(title: "이름을 입력해주세요.", message: nil, preferredStyle: .alert)
             let registerButton = UIAlertAction(title: "저장", style: .default, handler: { _ in


### PR DESCRIPTION
### OutLine
- #25 

### Work Contents
- 최근, 지역별 뷰를 오갈 때마다 뷰가 리로드되도록 함
- 원하는 플레이리스트로 내보내기를 실패하면 새로운 플레이리스트를 생성하도록 변경
- playlist를 애플뮤직으로 내보내는 로직 구현

### Review Note
<img width="30%" src="https://user-images.githubusercontent.com/63584245/195917723-d1cf4f9e-38a3-4ded-96bb-f8f317a5d266.jpeg"/>
<img width="30%" src="https://user-images.githubusercontent.com/63584245/195917798-6ed38f91-a84f-4562-a132-7931a2ed8759.jpeg"/>
<img width="30%" src="https://user-images.githubusercontent.com/63584245/195918082-82971f0e-775a-4a1d-ac3f-c0a817599608.jpeg"/>
<img width="30%" src="https://user-images.githubusercontent.com/63584245/195918088-1378fcc1-774c-4598-b1a1-498ed2fb2b21.jpeg"/>

- 내보내기를 눌러 플레이리스트를 내보냈을때 애플뮤직에서의 플레이리스트 description 문장을 어떻게 하는게 좋을까요?
