### PR TITLE
[Feat] #38 coredata playlist의 music 순서를 바꾸고 삭제할 수 있는 로직 추가

### DIFF
--- a/PLREQ/PLREQ/Models/PLREQDataManager.swift
+++ b/PLREQ/PLREQ/Models/PLREQDataManager.swift
@@ -102,4 +102,17 @@ class PLREQDataManager {
     func musicsFetch(playList: PlayListDB) -> [MusicDB] {
         return playList.music?.array as! [MusicDB]
     }
+    
+    // 음악을 삭제하는 로직
+    func musicDelete(music: NSManagedObject) -> Bool {
+        context.delete(music)
+        
+        do {
+            try context.save()
+            return true
+        } catch {
+            return false
+        }
+    }
+
 }

--- a/PLREQ/PLREQ/Models/PLREQDataManager.swift
+++ b/PLREQ/PLREQ/Models/PLREQDataManager.swift
@@ -69,34 +69,19 @@ class PLREQDataManager {
             (playListObject as! PlayListDB).addToMusic(musicObject)
         }
         
-        do {
-            try context.save()
-            return true
-        } catch {
-            return false
-        }
+        return saveContext()
     }
     
     func delete(playListObject: NSManagedObject) -> Bool {
         context.delete(playListObject)
         
-        do {
-            try context.save()
-            return true
-        } catch {
-            return false
-        }
+        return saveContext()
     }
     
     func updateTitle(playListObject: NSManagedObject, title: String) -> Bool {
         playListObject.setValue(title, forKey: "title")
         
-        do {
-            try context.save()
-            return true
-        } catch {
-            return false
-        }
+        return saveContext()
     }
     
     func musicsFetch(playList: PlayListDB) -> [MusicDB] {
@@ -107,12 +92,7 @@ class PLREQDataManager {
     func musicDelete(music: NSManagedObject) -> Bool {
         context.delete(music)
         
-        do {
-            try context.save()
-            return true
-        } catch {
-            return false
-        }
+        return saveContext()
     }
     
     // 바뀐 음악의 순서를 저장
@@ -127,6 +107,10 @@ class PLREQDataManager {
             }
         }
         
+        return saveContext()
+    }
+    
+    func saveContext() -> Bool {
         do {
             try context.save()
             return true

--- a/PLREQ/PLREQ/Models/PLREQDataManager.swift
+++ b/PLREQ/PLREQ/Models/PLREQDataManager.swift
@@ -114,5 +114,24 @@ class PLREQDataManager {
             return false
         }
     }
-
+    
+    // 바뀐 음악의 순서를 저장
+    func musicChangeOrder(playListObject: [NSManagedObject], musics: [MusicDB]) -> Bool {
+        for i in 0..<playListObject.count {
+            if i < musics.count {
+                playListObject[i].setValue(musics[i].title, forKey: "title")
+                playListObject[i].setValue(musics[i].artist, forKey: "artist")
+                playListObject[i].setValue(musics[i].musicImageURL, forKey: "musicImageURL")
+            } else {
+                context.delete(playListObject[i])
+            }
+        }
+        
+        do {
+            try context.save()
+            return true
+        } catch {
+            return false
+        }
+    }
 }


### PR DESCRIPTION
### OutLine
- #38 

### Work Contents
- [플레이리스트의 음악을 삭제하는 로직 추가](https://github.com/PLREQ/PLREQ/commit/94319ea31305795aede881d7334beb69c7fa84f8)
- [플레이리스트의 바뀐 음악의 순서를 저장하는 로직 추가](https://github.com/PLREQ/PLREQ/commit/0ea5369fc578a53216608996b9eacfae530d3f18)