### PR TITLE
[Feat] #48 화면 자동잠금 방지 로직 추가

### DIFF
--- a/PLREQ/PLREQ/Resources/SceneDelegate.swift
+++ b/PLREQ/PLREQ/Resources/SceneDelegate.swift
@@ -17,6 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
+        UIApplication.shared.isIdleTimerDisabled = true
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
@Juhwa-Lee1023 
@yeniful 
@2youngjun 

---
앱을 테스트하다보니 음악을 검색 중 앱에 아무런 액션을 하지 않아 iPhone의 화면이 자동잠금되어 앱이 background 모드로 변경되어 녹음이 중단되는 경우가 많아 화면 자동잠금을 방지하는 로직을 추가하였습니다.

---

### OutLine
- #48 

### Work Contents
- 화면 자동잠금 방지 로직 추가

### 고민한 점
- 앱이 항상 화면 자동 잠금 방지가 되는 것이 아니라 애플 개발자 문서에서 중요하게 이야기하였듯이 핵심 로직이 실행중일때만 화면 잠금 방지가 되도록 하여 해당 로직을 효율적으로 구현하기 위해 고민하였습니다.
<img width="763" alt="image" src="https://user-images.githubusercontent.com/63584245/196492389-54c789d4-7777-421e-85a6-cbfea426dcd7.png">

