### PR TITLE
[Bug] #51 playlistdetailview에서 노래들의 순서를 바꾸고 중간의 노래를 삭제하면 수정 사항이 정확하게 저장되지 않음

### DIFF
--- a/PLREQ/PLREQ/Models/PLREQDataManager.swift
+++ b/PLREQ/PLREQ/Models/PLREQDataManager.swift
@@ -98,13 +98,9 @@ class PLREQDataManager {
     // 바뀐 음악의 순서를 저장
     func musicChangeOrder(playListObject: [NSManagedObject], musics: [Music]) -> Bool {
         for i in 0..<playListObject.count {
-            if i < musics.count {
                 playListObject[i].setValue(musics[i].title, forKey: "title")
                 playListObject[i].setValue(musics[i].artist, forKey: "artist")
                 playListObject[i].setValue(musics[i].musicImageURL, forKey: "musicImageURL")
-            } else {
-                context.delete(playListObject[i])
-            }
         }
         
         return saveContext()

--- a/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
@@ -100,6 +100,7 @@ extension PlayListDetailViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
             let musicData = musicList[indexPath.row]
+            musics.remove(at: indexPath.row)
             PLREQDataManager.shared.musicDelete(music: musicData)
             tableView.deleteRows(at: [indexPath], with: .fade)
         } else {


### PR DESCRIPTION
@yeniful 
@2youngjun 
@LeeSungNo-ian 

---
안녕하세요. playlistdetailview에서 노래들의 순서를 바꾸고 중간의 노래를 삭제하면 수정 사항이 정확하게 저장되지 않는 버그가 확인되어 수정하였습니다.

---

### OutLine
- #51 

### Work Contents
- PlayListDetailView의 수정사항을 저장하는 배열에 삭제 로직 추가
- 불필요한 로직 삭제

### 버그 수정 전

https://user-images.githubusercontent.com/63584245/196704085-49daf80e-8391-4a45-a971-52f83d4d72af.MP4


### 버그 수정 후


https://user-images.githubusercontent.com/63584245/196704114-c3fce231-2a1a-4588-bcf0-1ac982949672.MP4




