### PR TITLE
[Bug] #52 PlayListView에서 PlayList 커버관련 버그 수정. 

### DIFF
--- a/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
@@ -19,9 +19,8 @@ final class PlayListDetailViewController: UIViewController {
     var musicList: [MusicDB]! {
         return playList.music?.array as? [MusicDB]
     }
-    
     var musics: [Music] = []
-    
+    var isEditCheck: Bool = false // 화면을 수정했는지 확인하는 변수
     var navigationTitleText: String! {
         return "\(playList.dataToString(forKey: "title"))"
     }
@@ -45,6 +44,9 @@ final class PlayListDetailViewController: UIViewController {
     
     override func viewDidDisappear(_ animated: Bool) {
         PLREQDataManager.shared.musicChangeOrder(playListObject: musicList, musics: musics)
+        if isEditCheck { // 뮤직 리스트를 수정 했다면 플레이리스트 reload
+            NotificationCenter.default.post(name: .viewReload, object: nil)
+        }
     }
     
     @IBAction func goToBackButton(_ sender: Any) {
@@ -99,6 +101,7 @@ extension PlayListDetailViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
+            isEditCheck.toggle()
             let musicData = musicList[indexPath.row]
             PLREQDataManager.shared.musicDelete(music: musicData)
             tableView.deleteRows(at: [indexPath], with: .fade)
@@ -113,7 +116,7 @@ extension PlayListDetailViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         let movedItem = musics[sourceIndexPath.row]
-        
+        isEditCheck.toggle()
         musics.remove(at: sourceIndexPath.row)
         musics.insert(movedItem, at: destinationIndexPath.row)
     }

--- a/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListTableViewCell.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListTableViewCell.swift
@@ -82,10 +82,14 @@ extension PlacePlayListTableViewCell: UICollectionViewDelegate, UICollectionView
         let playListData = playListList[indexPath.row]
         cell.delegate = self
         cell.indexPath = indexPath.row
-        cell.PlayListImageArr[0].load(url: playListData.dataToURL(forKey: "firstImageURL"))
-        cell.PlayListImageArr[1].load(url: playListData.dataToURL(forKey: "secondImageURL"))
-        cell.PlayListImageArr[2].load(url: playListData.dataToURL(forKey: "thirdImageURL"))
-        cell.PlayListImageArr[3].load(url: playListData.dataToURL(forKey: "fourthImageURL"))
+        let musicsData = (playListData as! PlayListDB).music?.array as? [MusicDB]
+        for i in 0..<4 {
+            if i < musicsData!.count {
+                cell.PlayListImageArr[i].load(url: musicsData![i].dataToURL(forKey: "musicImageURL"))
+            } else {
+                cell.PlayListImageArr[i].load(url: URL(string:"http://t1.daumcdn.net/thumb/R600x0/?fname=http%3A%2F%2Ft1.daumcdn.net%2Fqna%2Fimage%2F4b035cdf8372d67108f7e8d339660479dfb41bbd")!)
+            }
+        }
         
         cell.playListName.setLable(text: playListData.dataToString(forKey: "title"), fontSize: 14)
 

--- a/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListViewController.swift
@@ -119,9 +119,7 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
             let deleteCancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
             let deletePlayList = UIAlertAction(title: "플레이리스트 삭제", style: .destructive) { _ in
                 _ = PLREQDataManager.shared.delete(playListObject: self.playListList[indexPath])
-                self.playListList = PLREQDataManager.shared.fetch()
-                self.placeList.removeAll()
-                self.PlacePlayListTableView.reloadData()
+                NotificationCenter.default.post(name: .viewReload, object: nil)
             }
             deleteAlert.addAction(deleteCancel)
             deleteAlert.addAction(deletePlayList)
@@ -193,9 +191,7 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
                 guard var title = changeAlert.textFields?[0].text else { return }
                 if(title == "") { title = "PLREQ" }
                 _ = PLREQDataManager.shared.updateTitle(playListObject: self.playListList[indexPath], title: title)
-                self.playListList = PLREQDataManager.shared.fetch()
-                self.placeList.removeAll()
-                self.PlacePlayListTableView.reloadData()
+                NotificationCenter.default.post(name: .viewReload, object: nil)
             })
             let cancelButton = UIAlertAction(title: "취소", style: .destructive, handler: { _ in
                 changeAlert.dismiss(animated: true)

--- a/PLREQ/PLREQ/Views/PlayListView/PlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlayListViewController.swift
@@ -65,7 +65,6 @@ class PlayListViewController: UIViewController {
     
     @IBAction func selectButton(_ sender: UIButton) {
         if sender.titleLabel?.text == "최근" {
-            NotificationCenter.default.post(name: .viewReload, object: nil)
             RecentPlayListContainerView.isHidden = false
             PlacePlayListContainerView.isHidden = true
             recentButton.layer.addBorder([.bottom], color: .white, width: 2)
@@ -75,7 +74,6 @@ class PlayListViewController: UIViewController {
             }
             buttonCheck = false
         } else {
-            NotificationCenter.default.post(name: .viewReload, object: nil)
             RecentPlayListContainerView.isHidden = true
             PlacePlayListContainerView.isHidden = false
             placeButton.layer.addBorder([.bottom], color: .white, width: 2)

--- a/PLREQ/PLREQ/Views/PlayListView/RecentPlayListView/RecentPlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/RecentPlayListView/RecentPlayListViewController.swift
@@ -69,11 +69,15 @@ extension RecentPlayListViewController: UICollectionViewDelegate, UICollectionVi
         let playListData = playListList[indexPath.row]
         cell.delegate = self
         cell.indexPath = indexPath.row
-        cell.PlayListImageArr[0].load(url: playListData.dataToURL(forKey: "firstImageURL"))
-        cell.PlayListImageArr[1].load(url: playListData.dataToURL(forKey: "secondImageURL"))
-        cell.PlayListImageArr[2].load(url: playListData.dataToURL(forKey: "thirdImageURL"))
-        cell.PlayListImageArr[3].load(url: playListData.dataToURL(forKey: "fourthImageURL"))
-        
+        let musicsData = (playListData as! PlayListDB).music?.array as? [MusicDB]
+        for i in 0..<4 {
+            if i < musicsData!.count {
+                cell.PlayListImageArr[i].load(url: musicsData![i].dataToURL(forKey: "musicImageURL"))
+            } else {
+                cell.PlayListImageArr[i].load(url: URL(string:"http://t1.daumcdn.net/thumb/R600x0/?fname=http%3A%2F%2Ft1.daumcdn.net%2Fqna%2Fimage%2F4b035cdf8372d67108f7e8d339660479dfb41bbd")!)
+            }
+        }
+
         cell.playListName.setLable(text: playListData.dataToString(forKey: "title"), fontSize: 14)
         
         cell.playListDay.setLable(text: Date().toYMDString(date: playListData.dataToDate(forKey: "day")), fontSize: 12)
@@ -121,8 +125,7 @@ extension RecentPlayListViewController: collectionViewCelEditButtonlClicked {
             let deleteCancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
             let deletePlayList = UIAlertAction(title: "플레이리스트 삭제", style: .destructive) { _ in
                 _ = PLREQDataManager.shared.delete(playListObject: self.playListList[indexPath])
-                self.playListList = PLREQDataManager.shared.fetch()
-                self.RecentPlayListCollectionView.reloadData()
+                NotificationCenter.default.post(name: .viewReload, object: nil)
             }
             deleteAlert.addAction(deleteCancel)
             deleteAlert.addAction(deletePlayList)
@@ -193,8 +196,7 @@ extension RecentPlayListViewController: collectionViewCelEditButtonlClicked {
                 guard var title = changeAlert.textFields?[0].text else { return }
                 if(title == "") { title = "PLREQ" }
                 _ = PLREQDataManager.shared.updateTitle(playListObject: self.playListList[indexPath], title: title)
-                self.playListList = PLREQDataManager.shared.fetch()
-                self.RecentPlayListCollectionView.reloadData()
+                NotificationCenter.default.post(name: .viewReload, object: nil)
             })
             let cancelButton = UIAlertAction(title: "취소", style: .destructive, handler: { _ in
                 changeAlert.dismiss(animated: true)


### PR DESCRIPTION
@LeeSungNo-ian 
@yeniful 
@2youngjun 

---
안녕하세요. PlayListView에서 PlayList 커버관련 버그가 조금 있었는데 수정하고 효율성을 높였습니다!

---

### OutLine
- #52 

### Work Contents
- PlayListView에서 PlayList 커버들을 불러올때 플레이 리스트 내부의 정보가 바뀌어도 새로고침이 되지않음.
- 최근순, 지역별로 플레이리스트를 클릭하였을 때 매번 뷰가 로드 되며 커버이미지가 흔들리는 버그

### 버그 수정 후

https://user-images.githubusercontent.com/63584245/196711378-32560d52-e8ea-40ef-96b3-4f6aa7cfdb7d.MP4


## Review Note

**추가 기획 제안**

> 1. 사진을 매번 URL을 통해 불러오는 방식에 대해 논의가 필요할 것 같습니다! 사용자의 기기에 저장하는 방식이 더 효율적일 수도 있겠다는 생각이 드네요...
      

---


