### PR TITLE
[Feat] #62 1곡만 있는 경우 왼쪽 정렬로 수정

### DIFF
--- a/PLREQ/PLREQ/Views/PlayListView/PlayListView.storyboard
+++ b/PLREQ/PLREQ/Views/PlayListView/PlayListView.storyboard
@@ -188,7 +188,7 @@
                                 <rect key="frame" x="20" y="0.0" width="374" height="735"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Pcj-Tt-zfH">
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Pcj-Tt-zfH">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>


### PR DESCRIPTION

@LeeSungNo-ian 
@yeniful 
@2youngjun 

---
노래가 1곡만 있는 경우 왼쪽 정렬로 나오도록 수정하였습니다.

---

### OutLine
- #62 

### Work Contents
- 노래가 1곡만 있는 경우 왼쪽 정렬로 나오도록 수정
- `Estimate Size`의 `Automatic`을 
<img width="253" alt="image" src="https://user-images.githubusercontent.com/63584245/197035999-463a7351-740c-40c4-aa49-1590afb0ac25.png">
`None`으로 수정
<img width="254" alt="image" src="https://user-images.githubusercontent.com/63584245/197037040-6477ee81-8e6d-4815-bcbe-129d24707e1a.png">

### 결과물
<img width="254" alt="image" src="https://user-images.githubusercontent.com/63584245/197037067-a5210af7-6bef-4718-8f60-615ad1511bdb.jpeg">


- 