### PR TITLE
[Feat] #45 - 유저의 위치 정보를 표현하는 범위 변경 및 음악 매칭 시 발생하는 UI 이슈를 수정하였습니다.

### DIFF
--- a/PLREQ/PLREQ.xcodeproj/project.pbxproj
+++ b/PLREQ/PLREQ.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
+				DEVELOPMENT_TEAM = V8U96P27D9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "애플 뮤직 플레이리스트를 사용하기 위해서는 접근권한이 필요합니다.";
@@ -564,7 +564,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
+				DEVELOPMENT_TEAM = V8U96P27D9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "애플 뮤직 플레이리스트를 사용하기 위해서는 접근권한이 필요합니다.";

--- a/PLREQ/PLREQ/Extensions/UIImageView+.swift
+++ b/PLREQ/PLREQ/Extensions/UIImageView+.swift
@@ -29,7 +29,6 @@ extension UIImageView {
         gradient.startPoint = CGPoint(x: 0.0, y: 0.0)
         gradient.endPoint = CGPoint(x: 0.0, y: 1.0)
         gradient.frame = bounds
-//        gradient.opacity = 0.7
         layer.addSublayer(gradient)
     }
 }

--- a/PLREQ/PLREQ/Views/MatchView/MatchMusicCell.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchMusicCell.swift
@@ -18,6 +18,5 @@ class MatchMusicCell: UICollectionViewCell {
         self.musicArtist.textColor = UIColor(red: 200/255, green: 200/255, blue: 200/255, alpha: 1)
         self.musicArtist.font = UIFont(name: "AppleSDGothicNeo-Light", size: 16)
         self.musicImage.layer.cornerRadius = 10
-        self.musicImage.addMusicCellGradient()
     }
 }

--- a/PLREQ/PLREQ/Views/MatchView/MatchMusicCell.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchMusicCell.swift
@@ -15,8 +15,9 @@ class MatchMusicCell: UICollectionViewCell {
     override func layoutSubviews() {
         self.musicTitle.textColor = UIColor.white
         self.musicTitle.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 20)
+        self.musicTitle.font = .systemFont(ofSize: 20, weight: .regular)
         self.musicArtist.textColor = UIColor(red: 200/255, green: 200/255, blue: 200/255, alpha: 1)
-        self.musicArtist.font = UIFont(name: "AppleSDGothicNeo-Light", size: 16)
+        self.musicArtist.font = .systemFont(ofSize: 16, weight: .light)
         self.musicImage.layer.cornerRadius = 10
     }
 }

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -217,6 +217,7 @@ extension MatchViewController: UICollectionViewDataSource {
                 cell.musicImage.image = UIImage(data: data!)
             }
         }
+        cell.musicImage.addMusicCellGradient()
         return cell
     }
 }

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -162,14 +162,13 @@ class MatchViewController: UIViewController {
         
         let registerButton = UIAlertAction(title: "저장", style: .default, handler: { _ in
             guard let title = alert.textFields?[0].text else { return }
-//            let firstImageURL = self.recordedMusicList[0].musicImageURL
-//            let secondImageURL = self.recordedMusicList[1].musicImageURL
-//            let thirdImageURL = self.recordedMusicList[2].musicImageURL
-//            let fourthImageURL = self.recordedMusicList[3].musicImageURL
-
-            PLREQDataManager.shared.save(title: title, location: self.currentLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
+            if title == "" {
+                let placeHolder = "\(self.currentLocation)에서의 " + "\(self.currentTime)"
+                PLREQDataManager.shared.save(title: placeHolder, location: self.currentLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
+            } else {
+                PLREQDataManager.shared.save(title: title, location: self.currentLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
+            }
             self.viewModel?.stopListening()
-            
             self.recordedMusicList = [Music]()
             self.matchMusicCollectionView.reloadData()
             self.navigationController?.pushViewController(self.playListViewController, animated: true)
@@ -185,9 +184,9 @@ class MatchViewController: UIViewController {
             self.currentTimeFormatter(.now)
             switch CLLocationManager.authorizationStatus() {
             case .authorizedAlways, .authorizedWhenInUse:
-                textField.text = "\(self.currentLocation)에서의 " + "\(self.currentTime)"
+                textField.placeholder = "\(self.currentLocation)에서의 " + "\(self.currentTime)"
             case .denied, .notDetermined, .restricted:
-                textField.text = ""
+                textField.placeholder = ""
             default:
                 textField.placeholder = ""
             }
@@ -246,6 +245,8 @@ extension MatchViewController: UICollectionViewDelegateFlowLayout {
 extension MatchViewController: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let location = locations.first {
+            var locality = ""
+            var thoroughfare = ""
             self.currentLatitude = location.coordinate.latitude
             self.currentLongtitude = location.coordinate.longitude
             
@@ -254,7 +255,9 @@ extension MatchViewController: CLLocationManagerDelegate {
             let locale = Locale(identifier: "Ko-kr")
             geocoder.reverseGeocodeLocation(findLocation, preferredLocale: locale) { [weak self] (place, error) in
                 if let address: [CLPlacemark] = place {
-                    self?.currentLocation = "\(address.last?.locality ?? "")"
+                    locality = "\(address.last?.locality ?? "")"
+                    thoroughfare = "\(address.last?.thoroughfare ?? "")"
+                    self?.currentLocation = "\(locality) \(thoroughfare)"
                 }
             }
         }

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -51,7 +51,7 @@ class MatchViewController: UIViewController {
             if self.recordedMusicList.count == 0 {
                 self.isEmptyRecordedMusicListAlert()
             } else {
-                self.viewModel?.stopListening()
+//                self.stopSongMatching()
                 self.saveRecordedMusicList()
             }
         }
@@ -80,6 +80,10 @@ class MatchViewController: UIViewController {
         if self.viewModel == nil {
             self.viewModel = MatchViewModel(matchHandler: songMatched)
         }
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        self.stopSongMatching()
     }
     
     //MARK: Style Function
@@ -129,6 +133,11 @@ class MatchViewController: UIViewController {
         }
     }
     
+    private func stopSongMatching() {
+        self.viewModel?.audioEngine.stop()
+        self.viewModel?.audioEngine.inputNode.removeTap(onBus: 0)
+    }
+    
     private func viewDraw() {
         self.recordedMusic.title = self.viewModel?.title ?? ""
         self.recordedMusic.artist = self.viewModel?.artist ?? ""
@@ -153,12 +162,14 @@ class MatchViewController: UIViewController {
         
         let registerButton = UIAlertAction(title: "저장", style: .default, handler: { _ in
             guard let title = alert.textFields?[0].text else { return }
-            let firstImageURL = self.recordedMusicList[0].musicImageURL
-            let secondImageURL = self.recordedMusicList[1].musicImageURL
-            let thirdImageURL = self.recordedMusicList[2].musicImageURL
-            let fourthImageURL = self.recordedMusicList[3].musicImageURL
+//            let firstImageURL = self.recordedMusicList[0].musicImageURL
+//            let secondImageURL = self.recordedMusicList[1].musicImageURL
+//            let thirdImageURL = self.recordedMusicList[2].musicImageURL
+//            let fourthImageURL = self.recordedMusicList[3].musicImageURL
 
             PLREQDataManager.shared.save(title: title, location: self.currentLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
+            self.viewModel?.stopListening()
+            
             self.recordedMusicList = [Music]()
             self.matchMusicCollectionView.reloadData()
             self.navigationController?.pushViewController(self.playListViewController, animated: true)


### PR DESCRIPTION
@LeeSungNo-ian  
@yeniful 
@Juhwa-Lee1023 

---
안녕하세요! 

---

### OutLine
- #45 

### Work Contents
- 플레이리스트 저장 시 유저의 위치 정보를 표현하는 CLPlacemark 의 범위가 locality 에서 locality + thoroughfare 로 변경되었습니다. 
- 기존에 Alert TextField 의 text 로 제목이 자동 입력되었으나, 플레이리스트 타이틀을 placeholder 로 제공하되 유저가 따로 기입하지 않고 저장 시 placeholder 내용이 타이틀로 저장되도록 구현하였습니다. 
- Match 된 MusicCell 의 gradient 가 추가되는 이슈를 수정하였습니다. 

### App Action Screen

https://user-images.githubusercontent.com/86882798/197472906-906b7e97-3411-409b-beb0-109ded4d9340.MP4

