### PR TITLE
[Feat] #69 노래의 커버 이미지를 링크로 불러오는 방식이 아니라 파일로 저장하는 로직으로 변경

### DIFF
--- a/PLREQ/PLREQ.xcodeproj/project.pbxproj
+++ b/PLREQ/PLREQ.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = HD34Q2YK79;
+				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "애플 뮤직 플레이리스트를 사용하기 위해서는 접근권한이 필요합니다.";
@@ -564,7 +564,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = HD34Q2YK79;
+				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "애플 뮤직 플레이리스트를 사용하기 위해서는 접근권한이 필요합니다.";

--- a/PLREQ/PLREQ/Extensions/NSManagedObject+.swift
+++ b/PLREQ/PLREQ/Extensions/NSManagedObject+.swift
@@ -14,6 +14,10 @@ extension NSManagedObject {
         return self.value(forKey: forKey) as? String ?? "정보를 불러올 수 없습니다."
     }
     
+    func dataToData(forKey: String) -> Data {
+        return self.value(forKey: forKey) as! Data
+    }
+    
     func dataToURL(forKey: String) -> URL {
         return self.value(forKey: forKey) as? URL ?? URL(string:"http://t1.daumcdn.net/thumb/R600x0/?fname=http%3A%2F%2Ft1.daumcdn.net%2Fqna%2Fimage%2F4b035cdf8372d67108f7e8d339660479dfb41bbd")!
     }

--- a/PLREQ/PLREQ/Extensions/UIImageView+.swift
+++ b/PLREQ/PLREQ/Extensions/UIImageView+.swift
@@ -21,6 +21,12 @@ extension UIImageView {
         }
     }
     
+    // UIImageView에 Data로 이미지를 불러올 때 사용
+    func load(data: Data) {
+        self.contentMode = .scaleAspectFill
+        self.image = UIImage(data: data)
+    }
+    
     // MatchMusicCell Image Gradient
     func addMusicCellGradient() {
         let gradient: CAGradientLayer = CAGradientLayer()
@@ -31,4 +37,5 @@ extension UIImageView {
         gradient.frame = bounds
         layer.addSublayer(gradient)
     }
+    
 }

--- a/PLREQ/PLREQ/Models/MusicDB+CoreDataProperties.swift
+++ b/PLREQ/PLREQ/Models/MusicDB+CoreDataProperties.swift
@@ -17,7 +17,7 @@ extension MusicDB {
 
     @NSManaged public var title: String?
     @NSManaged public var artist: String?
-    @NSManaged public var musicImageURL: URL?
+    @NSManaged public var musicImage: Data?
     
     @NSManaged public var playlist: PlayListDB?
 

--- a/PLREQ/PLREQ/Models/PLREQDataManager.swift
+++ b/PLREQ/PLREQ/Models/PLREQDataManager.swift
@@ -50,7 +50,7 @@ class PLREQDataManager {
     }
     
     // 플레이리스트 저장
-    func save(title: String, location: String, day: Date, latitude: Double, longtitude: Double, musics: [Music]) {
+    func save(title: String, location: String, day: Date, latitude: Double, longtitude: Double, musics: [Music]) -> Bool {
         let playListObject = NSEntityDescription.insertNewObject(forEntityName: playListModelName, into: context)
         playListObject.setValue(title, forKey: "title")
         playListObject.setValue(day, forKey: "day")
@@ -61,20 +61,16 @@ class PLREQDataManager {
             let musicObject = NSEntityDescription.insertNewObject(forEntityName: MusicModelName, into: context) as! MusicDB
             musicObject.title = music.title
             musicObject.artist = music.artist
-            DispatchQueue.global().async { [self] in 
+            DispatchQueue.global().async {  
                 if let data = try? Data(contentsOf: music.musicImageURL) {
                     if let image = UIImage(data: data) {
                         musicObject.musicImage = image.jpegData(compressionQuality: 1.0)
                     }
                 }
                 (playListObject as! PlayListDB).addToMusic(musicObject)
-                do {
-                    try context.save()
-                } catch {
-                    //
-                }
             }
         }
+        return saveContext()
     }
     
     // 플레이리스트 삭제

--- a/PLREQ/PLREQ/Models/Struct+.swift
+++ b/PLREQ/PLREQ/Models/Struct+.swift
@@ -12,3 +12,9 @@ struct Music {
     var artist: String
     var musicImageURL: URL
 }
+
+struct MusicData {
+    var title: String
+    var artist: String
+    var musicImage: Data
+}

--- a/PLREQ/PLREQ/PLREQ.xcdatamodeld/PLREQ.xcdatamodel/contents
+++ b/PLREQ/PLREQ/PLREQ.xcdatamodeld/PLREQ.xcdatamodel/contents
@@ -2,7 +2,7 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Music" representedClassName=".MusicDB" syncable="YES">
         <attribute name="artist" optional="YES" attributeType="String"/>
-        <attribute name="musicImageURL" optional="YES" attributeType="URI"/>
+        <attribute name="musicImage" optional="YES" attributeType="Binary"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <relationship name="playlist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PlayList" inverseName="music" inverseEntity="PlayList"/>
     </entity>

--- a/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListDetailView/PlayListDetailViewController.swift
@@ -19,7 +19,7 @@ final class PlayListDetailViewController: UIViewController {
     var musicList: [MusicDB]! {
         return playList.music?.array as? [MusicDB]
     }
-    var musics: [Music] = []
+    var musics: [MusicData] = []
     var isEditCheck: Bool = false // 화면을 수정했는지 확인하는 변수
     var navigationTitleText: String! {
         return "\(playList.dataToString(forKey: "title"))"
@@ -90,7 +90,7 @@ extension PlayListDetailViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: "playListDetailCell", for: indexPath) as? PlayListDetailCell
         
         let musicData = musicList[indexPath.row]
-        cell?.musicImage.load(url: musicData.dataToURL(forKey: "musicImageURL"))
+        cell?.musicImage.load(data: musicData.dataToData(forKey: "musicImage"))
         cell?.musicImage.layer.cornerRadius = 6
 
         cell?.musicTitle.text = musicData.dataToString(forKey: "title")
@@ -167,8 +167,8 @@ private extension PlayListDetailViewController {
             let musicCellData = musicList[i]
             let title = musicCellData.dataToString(forKey: "title")
             let artist = musicCellData.dataToString(forKey: "artist")
-            let musicImageURL = musicCellData.dataToURL(forKey: "musicImageURL")
-            let music = Music(title: title, artist: artist, musicImageURL: musicImageURL)
+            let musicImage = musicCellData.dataToData(forKey: "musicImage")
+            let music = MusicData(title: title, artist: artist, musicImage: musicImage)
             musics.append(music)
         }
     }

--- a/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListTableViewCell.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListTableViewCell.swift
@@ -83,11 +83,12 @@ extension PlacePlayListTableViewCell: UICollectionViewDelegate, UICollectionView
         cell.delegate = self
         cell.indexPath = indexPath.row
         let musicsData = (playListData as! PlayListDB).music?.array as? [MusicDB]
+        
         for i in 0..<4 {
             if i < musicsData!.count {
-                cell.PlayListImageArr[i].load(url: musicsData![i].dataToURL(forKey: "musicImageURL"))
+                cell.PlayListImageArr[i].load(data: musicsData![i].dataToData(forKey: "musicImage"))
             } else {
-                cell.PlayListImageArr[i].load(url: URL(string:"http://t1.daumcdn.net/thumb/R600x0/?fname=http%3A%2F%2Ft1.daumcdn.net%2Fqna%2Fimage%2F4b035cdf8372d67108f7e8d339660479dfb41bbd")!)
+                cell.PlayListImageArr[i].image = UIImage()
             }
         }
         

--- a/PLREQ/PLREQ/Views/PlayListView/RecentPlayListView/RecentPlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/RecentPlayListView/RecentPlayListViewController.swift
@@ -86,9 +86,9 @@ extension RecentPlayListViewController: UICollectionViewDelegate, UICollectionVi
         let musicsData = (playListData as! PlayListDB).music?.array as? [MusicDB]
         for i in 0..<4 {
             if i < musicsData!.count {
-                cell.PlayListImageArr[i].load(url: musicsData![i].dataToURL(forKey: "musicImageURL"))
+                cell.PlayListImageArr[i].load(data: musicsData![i].dataToData(forKey: "musicImage"))
             } else {
-                cell.PlayListImageArr[i].load(url: URL(string:"http://t1.daumcdn.net/thumb/R600x0/?fname=http%3A%2F%2Ft1.daumcdn.net%2Fqna%2Fimage%2F4b035cdf8372d67108f7e8d339660479dfb41bbd")!)
+                cell.PlayListImageArr[i].image = UIImage()
             }
         }
 


### PR DESCRIPTION
@LeeSungNo-ian  
@yeniful 
@2youngjun 

---
안녕하세요! 노래의 커버 이미지를 링크로 불러오는 방식이 아니라 파일로 저장하는 로직으로 변경하였습니다!
---

### OutLine
- #69 

### Work Contents
- 기존에 노래의 커버 이미지를 URL로 불러오다보니 화면에 불러와야할 이미지가 많은 경우나 통신상태가 좋지않을때 뷰를 불러오는데 많은 시간이 소요되는 문제가 있었습니다.
- 그래서 이미지를 URL로 불러오는 방식이 아니라 CoreData에 이미지 파일로 저장하는 방식으로 구조 및 로직을 변경하였습니다!

### App Action Screen

https://user-images.githubusercontent.com/63584245/197528026-80644b7a-10c5-4379-be92-5ad7c1d96ee2.MP4



