### PR TITLE
[Feat] #50 음악을 매칭하다 앱이 종료되었을 경우, 재실행 시 매칭중이던 음악을 다시 가져와주는 기능을 구현했습니다.

### DIFF
--- a/PLREQ/PLREQ.xcodeproj/project.pbxproj
+++ b/PLREQ/PLREQ.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = HD34Q2YK79;
+				DEVELOPMENT_TEAM = V8U96P27D9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "애플 뮤직 플레이리스트를 사용하기 위해서는 접근권한이 필요합니다.";
@@ -564,7 +564,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = HD34Q2YK79;
+				DEVELOPMENT_TEAM = V8U96P27D9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "애플 뮤직 플레이리스트를 사용하기 위해서는 접근권한이 필요합니다.";

--- a/PLREQ/PLREQ.xcodeproj/project.pbxproj
+++ b/PLREQ/PLREQ.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0A145DA428FD657900590500 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A145DA328FD657900590500 /* UIImage+.swift */; };
 		0A9CD5F828F856E5002E4882 /* PlayListDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9CD5F728F856E5002E4882 /* PlayListDetailCell.swift */; };
+		8B3F69412907867C002F554E /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3F69402907867C002F554E /* UserDefaults+.swift */; };
 		8B93D54128E8789700AD8170 /* MatchMusicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93D54028E8789700AD8170 /* MatchMusicCell.swift */; };
 		8BFFE1AF28F8412700D183CE /* Struct+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFFE1AE28F8412700D183CE /* Struct+.swift */; };
 		D50154BD28F9D38E001BA8D5 /* Notification.Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50154BC28F9D38E001BA8D5 /* Notification.Name+.swift */; };
@@ -52,6 +53,7 @@
 /* Begin PBXFileReference section */
 		0A145DA328FD657900590500 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		0A9CD5F728F856E5002E4882 /* PlayListDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayListDetailCell.swift; sourceTree = "<group>"; };
+		8B3F69402907867C002F554E /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		8B93D54028E8789700AD8170 /* MatchMusicCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchMusicCell.swift; sourceTree = "<group>"; };
 		8BFFE1AE28F8412700D183CE /* Struct+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Struct+.swift"; sourceTree = "<group>"; };
 		D50154BC28F9D38E001BA8D5 /* Notification.Name+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+.swift"; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 				D50F95D528F59C9F0072CDB5 /* NSManagedObject+.swift */,
 				D50F95DB28F5DDE40072CDB5 /* UINavigationController+.swift */,
 				D50154BC28F9D38E001BA8D5 /* Notification.Name+.swift */,
+				8B3F69402907867C002F554E /* UserDefaults+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -366,6 +369,7 @@
 				D537200F28F4A50200753C36 /* PLREQDataManager.swift in Sources */,
 				D50F95D628F59C9F0072CDB5 /* NSManagedObject+.swift in Sources */,
 				D58069AB28E45C7500461CD8 /* PlayListDetailViewController.swift in Sources */,
+				8B3F69412907867C002F554E /* UserDefaults+.swift in Sources */,
 				D537201528F4A81A00753C36 /* PlayListDB+CoreDataProperties.swift in Sources */,
 				D58069B228E45C7500461CD8 /* PlayListCollectionViewCell.swift in Sources */,
 				D54C413A28E343F400C7C0FD /* ViewController.swift in Sources */,

--- a/PLREQ/PLREQ/Extensions/UIImageView+.swift
+++ b/PLREQ/PLREQ/Extensions/UIImageView+.swift
@@ -22,7 +22,8 @@ extension UIImageView {
     }
     
     // MatchMusicCell Image Gradient
-    func addMusicCellGradient() {
+    func addMusicCellGradient(imageView: UIImageView) {
+        guard imageView.layer.sublayers?.count != 1 else { return }
         let gradient: CAGradientLayer = CAGradientLayer()
         gradient.colors = [UIColor.clear.cgColor, UIColor(red: 0, green: 0, blue: 0, alpha: 0.5).cgColor]
         gradient.locations = [0.0 , 1.0]

--- a/PLREQ/PLREQ/Extensions/UserDefaults+.swift
+++ b/PLREQ/PLREQ/Extensions/UserDefaults+.swift
@@ -1,0 +1,31 @@
+//
+//  UserDefaults+.swift
+//  PLREQ
+//
+//  Created by 이영준 on 2022/10/25.
+//
+
+import Foundation
+
+extension UserDefaults: ObjectSavable {
+    func setObject<Object>(_ object: Object, forKey: String) throws where Object: Encodable {
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(object)
+            set(data, forKey: forKey)
+        } catch {
+            throw ObjectSavableError.unableToEncode
+        }
+    }
+    
+    func getObject<Object>(forKey: String, castTo type: Object.Type) throws -> Object where Object: Decodable {
+        guard let data = data(forKey: forKey) else { throw ObjectSavableError.noValue }
+        let decoder = JSONDecoder()
+        do {
+            let object = try decoder.decode(type, from: data)
+            return object
+        } catch {
+            throw ObjectSavableError.unableToDecode
+        }
+    }
+}

--- a/PLREQ/PLREQ/Models/Struct+.swift
+++ b/PLREQ/PLREQ/Models/Struct+.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Music {
+struct Music: Codable {
     var title: String
     var artist: String
     var musicImageURL: URL

--- a/PLREQ/PLREQ/Protocol/Protocol+.swift
+++ b/PLREQ/PLREQ/Protocol/Protocol+.swift
@@ -14,3 +14,17 @@ protocol collectionViewCellClicked {
 protocol collectionViewCelEditButtonlClicked {
     func buttonClicked(indexPath: Int)
 }
+
+protocol ObjectSavable {
+    func setObject<Object>(_ object: Object, forKey: String) throws where Object: Encodable
+    func getObject<Object>(forKey: String, castTo type: Object.Type) throws -> Object where Object: Decodable
+}
+
+enum ObjectSavableError: String, LocalizedError {
+    case unableToEncode = "Unable to encode object into data"
+    case noValue = "No data object found for the given key"
+    case unableToDecode = "Unable to decode object into given type"
+    var errorDescription: String? {
+        rawValue
+    }
+}

--- a/PLREQ/PLREQ/Resources/SceneDelegate.swift
+++ b/PLREQ/PLREQ/Resources/SceneDelegate.swift
@@ -17,7 +17,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
-        UIApplication.shared.isIdleTimerDisabled = true
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/PLREQ/PLREQ/ViewModels/MatchViewModel.swift
+++ b/PLREQ/PLREQ/ViewModels/MatchViewModel.swift
@@ -57,6 +57,7 @@ class MatchViewModel: NSObject {
     }
     
     func stopListening() {
+        
         audioEngine.stop()
         audioEngine.inputNode.removeTap(onBus: 0)
     }

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -43,11 +43,14 @@ class MatchViewController: UIViewController {
     @IBAction func tapRecordButton(_ sender: UIButton) {
         self.isListening.toggle()
         if self.isListening {
+            // 음악 매칭 시 Display 가 꺼지지 않도록 구현
+            UIApplication.shared.isIdleTimerDisabled = true
             // 30초 동안 한번씩 songSearch 함수 실행
             self.locationManager.requestLocation()
             timer = Timer.scheduledTimer(timeInterval: 0, target: self, selector: #selector(catchMusic), userInfo: nil, repeats: false)
             timer = Timer.scheduledTimer(timeInterval: 30.0, target: self, selector: #selector(catchMusic), userInfo: nil, repeats: true)
         } else {
+            UIApplication.shared.isIdleTimerDisabled = false
             timer?.invalidate()
             if self.recordedMusicList.count == 0 {
                 self.isEmptyRecordedMusicListAlert()
@@ -217,7 +220,7 @@ extension MatchViewController: UICollectionViewDataSource {
                 cell.musicImage.image = UIImage(data: data!)
             }
         }
-        cell.musicImage.addMusicCellGradient()
+        cell.musicImage.addMusicCellGradient(imageView: cell.musicImage)
         return cell
     }
 }

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -33,6 +33,7 @@ class MatchViewController: UIViewController {
     var savedLocation: String = ""
     var currentLatitude: CLLocationDegrees = 0.0
     var currentLongtitude: CLLocationDegrees = 0.0
+    let userDefaults = UserDefaults.standard
     
     //MARK: IBOutlet Variable
     @IBOutlet weak var playListButton: UIButton!
@@ -77,6 +78,14 @@ class MatchViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.styleFunction()
+        self.getUserDefaultsPlayList()
+        
+        if self.recordedMusicList.isEmpty {
+            return
+        } else {
+            self.matchMusicCollectionView.reloadData()
+            self.reactivateAlert()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -139,6 +148,7 @@ class MatchViewController: UIViewController {
         self.recordedMusic.musicImageURL = self.viewModel?.musicImageURL ?? URL(string: "https://is3-ssl.mzstatic.com/image/thumb/Music128/v4/46/e3/8c/46e38c01-05a5-5787-af4b-593dde5ba586/8809550047556.jpg/800x800bb.jpg")!
         
         self.recordedMusicList.insert(self.recordedMusic, at: 0)
+        self.setUserDefaultsPlayList()
         self.matchMusicCollectionView.reloadData()
     }
     
@@ -164,6 +174,7 @@ class MatchViewController: UIViewController {
                 PLREQDataManager.shared.save(title: title, location: self.savedLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
             }
             self.recordedMusicList = [Music]()
+            self.setUserDefaultsPlayList()
             self.matchMusicCollectionView.reloadData()
             self.navigationController?.pushViewController(self.playListViewController, animated: true)
         })
@@ -186,6 +197,37 @@ class MatchViewController: UIViewController {
             }
         })
         self.present(alert, animated: true)
+    }
+    
+    private func reactivateAlert() {
+        let alert = UIAlertController(title: "이전에 기록해놓은 음악이에요", message: "계속해서 음악을 기록할까요?", preferredStyle: .alert)
+        let confirm = UIAlertAction(title: "남기기", style: .default) { _ in
+            alert.dismiss(animated: true)
+        }
+        let rebase = UIAlertAction(title: "비우기", style: .cancel) { _ in
+            self.recordedMusicList = [Music]()
+            self.matchMusicCollectionView.reloadData()
+            self.setUserDefaultsPlayList()
+        }
+        [confirm, rebase].forEach(alert.addAction(_:))
+        
+        self.present(alert, animated: true)
+    }
+    
+    private func setUserDefaultsPlayList() {
+        do {
+            try userDefaults.setObject(self.recordedMusicList, forKey: "LoadedPlayList")
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
+    private func getUserDefaultsPlayList() {
+        do {
+            try self.recordedMusicList = userDefaults.getObject(forKey: "LoadedPlayList", castTo: [Music].self)
+        } catch {
+            print(error.localizedDescription)
+        }
     }
     
     private func currentTimeFormatter(_ date: Date) {

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -30,6 +30,7 @@ class MatchViewController: UIViewController {
     let locationManager = CLLocationManager()
     var currentTime: String = ""
     var currentLocation: String = ""
+    var savedLocation: String = ""
     var currentLatitude: CLLocationDegrees = 0.0
     var currentLongtitude: CLLocationDegrees = 0.0
     
@@ -109,7 +110,7 @@ class MatchViewController: UIViewController {
     private func configureNoRecordedMusicLabel() {
         self.noRecordedMusicLabel.text = "하단의 버튼을 눌러 음악을 찾아보세요."
         self.noRecordedMusicLabel.textColor = .white
-        self.noRecordedMusicLabel.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 20)
+        self.noRecordedMusicLabel.font = .systemFont(ofSize: 20, weight: .bold)
     }
     
     //MARK: Shazam Function
@@ -158,9 +159,9 @@ class MatchViewController: UIViewController {
             guard let title = alert.textFields?[0].text else { return }
             if title == "" {
                 let placeHolder = "\(self.currentLocation)에서의 " + "\(self.currentTime)"
-                PLREQDataManager.shared.save(title: placeHolder, location: self.currentLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
+                PLREQDataManager.shared.save(title: placeHolder, location: self.savedLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
             } else {
-                PLREQDataManager.shared.save(title: title, location: self.currentLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
+                PLREQDataManager.shared.save(title: title, location: self.savedLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
             }
             self.recordedMusicList = [Music]()
             self.matchMusicCollectionView.reloadData()
@@ -239,6 +240,7 @@ extension MatchViewController: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let location = locations.first {
             var locality = ""
+            var subLocality = ""
             var thoroughfare = ""
             self.currentLatitude = location.coordinate.latitude
             self.currentLongtitude = location.coordinate.longitude
@@ -249,7 +251,9 @@ extension MatchViewController: CLLocationManagerDelegate {
             geocoder.reverseGeocodeLocation(findLocation, preferredLocale: locale) { [weak self] (place, error) in
                 if let address: [CLPlacemark] = place {
                     locality = "\(address.last?.locality ?? "")"
+                    subLocality = "\(address.last?.subLocality ?? "")"
                     thoroughfare = "\(address.last?.thoroughfare ?? "")"
+                    self?.savedLocation = "\(locality) \(subLocality)"
                     self?.currentLocation = "\(locality) \(thoroughfare)"
                 }
             }

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -48,10 +48,10 @@ class MatchViewController: UIViewController {
             timer = Timer.scheduledTimer(timeInterval: 0, target: self, selector: #selector(catchMusic), userInfo: nil, repeats: false)
             timer = Timer.scheduledTimer(timeInterval: 30.0, target: self, selector: #selector(catchMusic), userInfo: nil, repeats: true)
         } else {
+            timer?.invalidate()
             if self.recordedMusicList.count == 0 {
                 self.isEmptyRecordedMusicListAlert()
             } else {
-//                self.stopSongMatching()
                 self.saveRecordedMusicList()
             }
         }
@@ -80,10 +80,6 @@ class MatchViewController: UIViewController {
         if self.viewModel == nil {
             self.viewModel = MatchViewModel(matchHandler: songMatched)
         }
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        self.stopSongMatching()
     }
     
     //MARK: Style Function
@@ -133,11 +129,6 @@ class MatchViewController: UIViewController {
         }
     }
     
-    private func stopSongMatching() {
-        self.viewModel?.audioEngine.stop()
-        self.viewModel?.audioEngine.inputNode.removeTap(onBus: 0)
-    }
-    
     private func viewDraw() {
         self.recordedMusic.title = self.viewModel?.title ?? ""
         self.recordedMusic.artist = self.viewModel?.artist ?? ""
@@ -168,7 +159,6 @@ class MatchViewController: UIViewController {
             } else {
                 PLREQDataManager.shared.save(title: title, location: self.currentLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
             }
-            self.viewModel?.stopListening()
             self.recordedMusicList = [Music]()
             self.matchMusicCollectionView.reloadData()
             self.navigationController?.pushViewController(self.playListViewController, animated: true)


### PR DESCRIPTION
@LeeSungNo-ian  
@yeniful 
@Juhwa-Lee1023 

---
안녕하세요! 

---

### OutLine
- #50 

### Work Contents
- 음악 매칭 버튼을 다시 클릭하였을 시 timer.invalidate() 메서드를 통해 음악 매칭을 중단하도록 구현하였습니다.
- 음악 매칭 중일 때 저전력 모드 활성화로 인한 화면 자동 잠금 기능을 제한하였습니다.
- 플레이리스트 저장 시 User Location CLPlacemark 를 locality+thoroughfare 에서  locality+subLocality 로 변경하였습니다.
- 앱을 녹음 중에 종료 후 재실행시, 녹음 중이던 플레이리스트를 가져오는 기능을 UserDefaults 를 통해 구현하였습니다.

### To Reviewer
- 기본 타입인 Int, Double, String 타입의 경우 아카아빙, 언아카이빙이 내부적으로 UserDefaults를 사용할 때 적용이 되기 떄문에 바로 사용 가능하지만, struct 의 경우 아카이빙, 언아카이빙 작업이 별도로 필요하더라구요!