### PR TITLE
[Feat] #90 applemusic 관련 기능을 사용할 때 구독 중인지 확인하고 구동 중이지 않다면 alert를 띄우는 로직 추가

### DIFF
--- a/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
+++ b/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
@@ -8,24 +8,11 @@
 import Foundation
 import MusicKit
 import StoreKit
+import Combine
 
 @available(iOS 16.0, *)
 final class AppleMusicExport: MusicPlaylistAddable, Sendable {
     var id: MusicItemID = ""
-    var check: Bool = false
-    
-    // 사용자가 애플 뮤직을 구독 중인지 확인
-    func appleMusicSubscription() -> Bool {
-        SKCloudServiceController().requestCapabilities { (capability:SKCloudServiceCapability, err:Error?) in
-            // 에러 발생시
-            guard err == nil else { return }
-            // 사용자가 애플 뮤직을 구독 중이라면
-            if capability.contains(SKCloudServiceCapability.musicCatalogPlayback) { self.check = true }
-            // 사용자가 애플 뮤직을 구독 중이지 않다면
-            if capability.contains(SKCloudServiceCapability.musicCatalogSubscriptionEligible) { self.check = false }
-        }
-        return check
-    }
     
     // 플레이리스트 추가 및 음악 목록 추가
     func addPlayList(name: String, musicList: [String]) {
@@ -81,4 +68,22 @@ final class AppleMusicExport: MusicPlaylistAddable, Sendable {
     // 이름을 지정해서 해당 플레이리스트에서 노래 불러오기
     // 개발 예정
     
+}
+
+class CheckAppleMusicSubscription: ObservableObject {
+    @Published var check: Bool = false
+    
+    // 사용자가 애플 뮤직을 구독 중인지 확인
+    func appleMusicSubscription() {
+        SKCloudServiceController().requestCapabilities { (capability:SKCloudServiceCapability, err:Error?) in
+            // 에러 발생시
+            guard err == nil else { return }
+            // 사용자가 애플 뮤직을 구독 중이라면
+            if capability.contains(SKCloudServiceCapability.musicCatalogPlayback) { self.check = false
+                
+            }
+            // 사용자가 애플 뮤직을 구독 중이지 않다면
+            if capability.contains(SKCloudServiceCapability.musicCatalogSubscriptionEligible) { self.check = false }
+        }
+    }
 }

--- a/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
+++ b/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
@@ -43,7 +43,9 @@ final class AppleMusicExport: MusicPlaylistAddable, Sendable {
                             var request = MusicCatalogSearchRequest.init(term: musicTitle, types: [Song.self])
                             request.includeTopResults = true
                             let response = try await request.response()
-                            try await MusicLibrary.shared.add(response.songs.first!, to: libraryResponse.playlists[0])
+                            if !response.songs.isEmpty { // 검색한 노래가 있는지 화기인
+                                try await MusicLibrary.shared.add(response.songs.first!, to: libraryResponse.playlists[0])
+                            }
                         }
                     }
                 }
@@ -72,7 +74,7 @@ final class AppleMusicExport: MusicPlaylistAddable, Sendable {
 
 class CheckAppleMusicSubscription: ObservableObject {
     @Published var check: Bool = false
-    
+    static let shared: CheckAppleMusicSubscription = CheckAppleMusicSubscription()
     // 사용자가 애플 뮤직을 구독 중인지 확인
     func appleMusicSubscription() {
         SKCloudServiceController().requestCapabilities { (capability:SKCloudServiceCapability, err:Error?) in

--- a/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
+++ b/PLREQ/PLREQ/ViewModels/PlayListDetailView/AppleMusicExport.swift
@@ -79,9 +79,7 @@ class CheckAppleMusicSubscription: ObservableObject {
             // 에러 발생시
             guard err == nil else { return }
             // 사용자가 애플 뮤직을 구독 중이라면
-            if capability.contains(SKCloudServiceCapability.musicCatalogPlayback) { self.check = false
-                
-            }
+            if capability.contains(SKCloudServiceCapability.musicCatalogPlayback) { self.check = true }
             // 사용자가 애플 뮤직을 구독 중이지 않다면
             if capability.contains(SKCloudServiceCapability.musicCatalogSubscriptionEligible) { self.check = false }
         }

--- a/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlacePlayListView/PlacePlayListViewController.swift
@@ -146,6 +146,7 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
                 let appleAlert = UIAlertController(title: "정말 내보내시겠어요?", message: "'\(self.playListList[indexPath].dataToString(forKey: "title"))'으로 저장됩니다.", preferredStyle: .alert)
                 let appleCancel = UIAlertAction(title: "취소", style: .destructive, handler: nil)
                 let addPlayList = UIAlertAction(title: "플레이리스트 내보내기", style: .default) { _ in
+                    CheckAppleMusicSubscription.shared.appleMusicSubscription()
                     let musicLists = (self.playListList[indexPath] as! PlayListDB).music?.array as? [MusicDB]
                     var musicListsTitle: [String] = []
                     for i in 0..<musicLists!.count {
@@ -180,6 +181,7 @@ extension PlacePlayListViewController: collectionViewCellClicked, collectionView
                     }
                     AppleMusicExport().addSongsToPlayList(name: playlistTitle, musicList: musicListsTitle)
                     appleNameAlert.dismiss(animated: true)
+                    CheckAppleMusicSubscription.shared.appleMusicSubscription()
                 } else {
                     let appleAlert = UIAlertController(title: "애플 뮤직 관련 기능을 사용하실려면 iOS 16버전 이상의 버전이 필요합니다.", message: "사용하시려면 iOS 버전을 확인해주세요.", preferredStyle: .alert)
                     let appleCancel = UIAlertAction(title: "확인", style: .cancel, handler: nil)

--- a/PLREQ/PLREQ/Views/PlayListView/PlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/PlayListViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import CoreData
+import SwiftUI
+import Combine
 
 class PlayListViewController: UIViewController {
     
@@ -26,10 +28,20 @@ class PlayListViewController: UIViewController {
     var playListList: [NSManagedObject] {
         return PLREQDataManager.shared.fetch()
     }
+    @ObservedObject var checkAppleMusicSubscription = CheckAppleMusicSubscription.shared
+    var cancelBag = Set<AnyCancellable>()
+    var isCheck: Bool = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setButton()
+        self.checkAppleMusicSubscription.$check
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] _ in
+                if self!.isCheck { if !self!.checkAppleMusicSubscription.check { self!.checkMusicSubscirption() } }
+                self!.isCheck = true
+            })
+            .store(in: &self.cancelBag)
         // Do any additional setup after loading the view.
     }
     
@@ -104,4 +116,12 @@ class PlayListViewController: UIViewController {
         playListButtonStackView.layer.addBorder([.bottom], color: .gray, width: 1)
         
     }
+    
+    private func checkMusicSubscirption() {
+        let appleAlert = UIAlertController(title: "애플 뮤직을 구독중인지 확인해주세요.", message: "애플 뮤직을 구독하고 계시지않으면 내보내기를 할 수 없어요.", preferredStyle: .alert)
+        let appleConfirm = UIAlertAction(title: "확인", style: .default, handler: nil)
+        appleAlert.addAction(appleConfirm)
+        self.present(appleAlert, animated: true, completion: nil)
+    }
+    
 }

--- a/PLREQ/PLREQ/Views/PlayListView/RecentPlayListView/RecentPlayListViewController.swift
+++ b/PLREQ/PLREQ/Views/PlayListView/RecentPlayListView/RecentPlayListViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import CoreData
+import SwiftUI
+import Combine
 
 class RecentPlayListViewController: UIViewController {
     
@@ -15,13 +17,16 @@ class RecentPlayListViewController: UIViewController {
     var playListList: [NSManagedObject] = []
     let playListCollectionViewCellNib: UINib = UINib(nibName: "PlayListCollectionViewCell", bundle: nil)
     let playListCollectionViewCell: String = "PlayListCollectionViewCell"
-    
+    @ObservedObject var checkAppleMusicSubscription = CheckAppleMusicSubscription()
+    var cancelBag = Set<AnyCancellable>()
+    var isCheck: Bool = false
     private lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(refreshReloadCollectView), for: .valueChanged)
         
         return refreshControl
     }()
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -30,6 +35,13 @@ class RecentPlayListViewController: UIViewController {
         registerNib()
         setAutoLayout()
         NotificationCenter.default.addObserver(self, selector: #selector(reloadView), name: .viewReload, object: nil)
+        self.checkAppleMusicSubscription.$check
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] _ in
+                if self!.isCheck { if !self!.checkAppleMusicSubscription.check { self!.checkMusicSubscirption() } }
+                self!.isCheck = true
+            })
+            .store(in: &self.cancelBag)
     }
     
     @objc func refreshReloadCollectView() {
@@ -41,6 +53,13 @@ class RecentPlayListViewController: UIViewController {
     @objc func reloadView(_ noti: Notification) {
         self.playListList = PLREQDataManager.shared.fetch()
         self.recentPlayListCollectionView.reloadData()
+    }
+    
+    private func checkMusicSubscirption() {
+        let appleAlert = UIAlertController(title: "애플 뮤직을 구독중인지 확인해주세요.", message: "애플 뮤직을 구독하고 계시지않으면 내보내기를 할 수 없어요.", preferredStyle: .alert)
+        let appleConfirm = UIAlertAction(title: "확인", style: .default, handler: nil)
+        appleAlert.addAction(appleConfirm)
+        self.present(appleAlert, animated: true, completion: nil)
     }
     
     private func collectionViewLink() {
@@ -91,7 +110,7 @@ extension RecentPlayListViewController: UICollectionViewDelegate, UICollectionVi
                 cell.PlayListImageArr[i].image = UIImage()
             }
         }
-
+        
         cell.playListName.setLable(text: playListData.dataToString(forKey: "title"), fontSize: 14)
         
         cell.playListDay.setLable(text: Date().toYMDString(date: playListData.dataToDate(forKey: "day")), fontSize: 12)
@@ -151,6 +170,7 @@ extension RecentPlayListViewController: collectionViewCelEditButtonlClicked {
                 let appleAlert = UIAlertController(title: "정말 내보내시겠어요?", message: "'\(self.playListList[indexPath].dataToString(forKey: "title"))'으로 저장됩니다.", preferredStyle: .alert)
                 let appleCancel = UIAlertAction(title: "취소", style: .destructive, handler: nil)
                 let addPlayList = UIAlertAction(title: "플레이리스트 내보내기", style: .default) { _ in
+                    self.checkAppleMusicSubscription.appleMusicSubscription()
                     let musicLists = (self.playListList[indexPath] as! PlayListDB).music?.array as? [MusicDB]
                     var musicListsTitle: [String] = []
                     for i in 0..<musicLists!.count {
@@ -173,6 +193,7 @@ extension RecentPlayListViewController: collectionViewCelEditButtonlClicked {
         let appleName = UIAlertAction(title: "애플뮤직 특정 플레이리스트에 추가하기", style: .default) { _ in
             let appleNameAlert = UIAlertController(title: "이름을 입력해주세요.\n(일치하는 플레이리스트가 없다면 입력한 이름으로 저장됩니다.)", message: nil, preferredStyle: .alert)
             let registerButton = UIAlertAction(title: "저장", style: .default, handler: { _ in
+                self.checkAppleMusicSubscription.appleMusicSubscription()
                 if #available(iOS 16.0, *) {
                     guard var playlistTitle = appleNameAlert.textFields?[0].text else { return }
                     if((playlistTitle == "")) { playlistTitle = self.playListList[indexPath].dataToString(forKey: "title") }


### PR DESCRIPTION
@yeniful 
@LeeSungNo-ian 
@2youngjun 

---

안녕하세요! applemusic 관련 기능을 사용할 때 구독 중인지 확인하고 구동 중이지 않다면 alert를 띄우는 로직을 추가하였습니다.

---

### OutLine
- #83 

### Work Contents
- applemusic 관련 기능을 사용할 때 구독 중인지 확인하고 구동 중이지 않다면 alert를 띄우는 로직 추가


https://user-images.githubusercontent.com/63584245/198844654-51f47f3c-39ad-4993-b066-0ba6fe9d6692.MP4

### To Reviewer
- 애플 뮤직을 구독 중이지 않으신 분들 기능 확인 한번 부탁드립니다!
