### PR TITLE
[Feat] #96 MapView와 DetailPlayListView 연결

### DIFF
--- a/PLREQ/PLREQ/Views/MapView/MapViewController.swift
+++ b/PLREQ/PLREQ/Views/MapView/MapViewController.swift
@@ -160,6 +160,23 @@ extension MapViewController: CLLocationManagerDelegate {
 }
 
 extension MapViewController: MKMapViewDelegate {
+    
+    func mapView(_ mapView: MKMapView, didSelect annotation: MKAnnotation) {
+
+        if let annotation = annotation as? CustomAnnotation {
+
+            let storyBoard = UIStoryboard(name: "PlayListDetailView", bundle: nil)
+
+            guard let playListDetailViewController = storyBoard.instantiateViewController(withIdentifier: "PlayListDetailView") as? PlayListDetailViewController else { return }
+
+            playListDetailViewController.playList = annotation.playList
+
+            self.navigationController?.pushViewController(playListDetailViewController, animated: true)
+        }
+        
+        // selected된 annotation을 deselected로 전환합니다
+        mapView.deselectAnnotation(annotation, animated: false)
+    }
 
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
         


### PR DESCRIPTION
@Juhwa-Lee1023 
@LeeSungNo-ian 
@2youngjun 

---

안녕하세요! 코인! 이안! 준! 어제 올렸던 PR #92 의 To Reviewers 에 적어둔대로 오늘은 `MapView`와 `PlayListDetailView`를 연결하는 작업을 했어요

---

### OutLine
- #96 

### Work Contents
![ezgif-3-21517b482c](https://user-images.githubusercontent.com/77262576/198894653-36d1b7ab-e7da-4020-8ee8-854a9fc76278.gif)
- MapView와 DetailPlayListView 연결

### To Reviewers
- Annotation이 TableVeiw나 CollectionView의 Cell과 비슷하다는 같다는 생각이 들었어요. 또 AnnotationView를 통해서 Annotaiton에 직접 접근할 수 있을 줄 알았는데 접근이 불가능했고, Annotation에 접근하기 위한 메서드를 별도로 제공하고 있더라구요.

- 또 재미있던 사실은 Annotation을 Tap했을 때에 대한 메서드는 없고 `didSelect`로 제공하고 있어서 임으로 `deselect`하는 과정을 추가해주었습니다. `didSelect`를 해주지 않을 시에 두번 째 눌렀을 때 선택이 안되는 문제가 생기더라고요!

- 다음 작업으로 Spotify에 플레이리스트를 export하는 기능을 구현해보려고 합니다!



