### PR TITLE
[Feat] #98 MatchView 에서의 수정 사항을 반영하고, 음악 매칭 관련 이슈를 해결하였습니다. 

### DIFF
--- a/PLREQ/PLREQ.xcodeproj/project.pbxproj
+++ b/PLREQ/PLREQ.xcodeproj/project.pbxproj
@@ -540,7 +540,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 22A6RK2943;
+				DEVELOPMENT_TEAM = V8U96P27D9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "애플 뮤직 플레이리스트를 사용하기 위해서는 접근권한이 필요합니다.";
@@ -581,7 +581,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 22A6RK2943;
+				DEVELOPMENT_TEAM = V8U96P27D9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PLREQ/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "애플 뮤직 플레이리스트를 사용하기 위해서는 접근권한이 필요합니다.";

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -58,6 +58,7 @@ class MatchViewController: UIViewController {
             UIApplication.shared.isIdleTimerDisabled = false
             self.recordButton.setImage(UIImage(named: "play"), for: .normal)
             timer?.invalidate()
+            viewModel?.stopListening()
             if self.recordedMusicList.count == 0 {
                 self.isEmptyRecordedMusicListAlert()
             } else {

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -47,8 +47,10 @@ class MatchViewController: UIViewController {
         if self.isListening {
             // 음악 매칭 시 Display 가 꺼지지 않도록 구현
             UIApplication.shared.isIdleTimerDisabled = true
-            // 30초 동안 한번씩 songSearch 함수 실행
+            // 음악 매칭 시도 시 한번만 유저의 현재 위치 요청
             self.locationManager.requestLocation()
+            
+            // 30초 동안 한번씩 songSearch 함수 실행
             timer = Timer.scheduledTimer(timeInterval: 0, target: self, selector: #selector(catchMusic), userInfo: nil, repeats: false)
             timer = Timer.scheduledTimer(timeInterval: 30.0, target: self, selector: #selector(catchMusic), userInfo: nil, repeats: true)
             self.recordButton.setImage(UIImage(named: "pause"), for: .normal)
@@ -170,8 +172,12 @@ class MatchViewController: UIViewController {
         let registerButton = UIAlertAction(title: "저장", style: .default, handler: { _ in
             guard let title = alert.textFields?[0].text else { return }
             if title == "" {
-                let placeHolder = "\(self.currentLocation)에서의 " + "\(self.currentTime)"
-                PLREQDataManager.shared.save(title: placeHolder, location: self.savedLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
+                if self.currentLocation == "" {
+                    PLREQDataManager.shared.save(title: "\(self.currentTime)의 여기, 이곳에서", location: self.savedLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
+                } else {
+                    let placeHolder = "\(self.currentLocation)에서의 " + "\(self.currentTime)"
+                    PLREQDataManager.shared.save(title: placeHolder, location: self.savedLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
+                }
             } else {
                 PLREQDataManager.shared.save(title: title, location: self.savedLocation, day: Date(), latitude: self.currentLatitude, longtitude: self.currentLongtitude, musics: self.recordedMusicList)
             }
@@ -191,7 +197,11 @@ class MatchViewController: UIViewController {
             self.currentTimeFormatter(.now)
             switch CLLocationManager.authorizationStatus() {
             case .authorizedAlways, .authorizedWhenInUse:
-                textField.placeholder = "\(self.currentLocation)에서의 " + "\(self.currentTime)"
+                if self.currentLocation == "" {
+                    textField.placeholder = ""
+                } else {
+                    textField.placeholder = "\(self.currentLocation)에서의 " + "\(self.currentTime)"
+                }
             case .denied, .notDetermined, .restricted:
                 textField.placeholder = ""
             default:
@@ -206,7 +216,7 @@ class MatchViewController: UIViewController {
         let confirm = UIAlertAction(title: "남기기", style: .default) { _ in
             alert.dismiss(animated: true)
         }
-        let rebase = UIAlertAction(title: "비우기", style: .cancel) { _ in
+        let rebase = UIAlertAction(title: "비우기", style: .destructive) { _ in
             self.recordedMusicList = [Music]()
             self.matchMusicCollectionView.reloadData()
             self.setUserDefaultsPlayList()


### PR DESCRIPTION
@LeeSungNo-ian  
@yeniful 
@Juhwa-Lee1023 

---
안녕하세요! 이전 PR에서 피드백 주셨던 부분을 수정하였고, 추가적인 음악 매칭 관련 이슈를 해결하였습니다. 감사합니다!

---

### OutLine
- #98 

### Work Contents
- 유저의 위치를 받아오지 못한 채 음악 매칭이 종료되었을 시 저장되는 플레이리스트 이름을 추가하였습니다.
- 30초 마다 수행되는 음악 매칭 도중에 pause 버튼을 누를 시 그대로 음악 매칭이 지속되고 매칭된 음악이 플레이리스트에 쌓이는 이슈를 해결하였습니다.
- 이전에 매칭되었던 음악에 대한 Alert 에서 `비우기` 버튼 스타일을 cancel → destructive 로 수정하였습니다.

### App Action Screen
https://user-images.githubusercontent.com/86882798/199260231-1f1acb1e-4901-4254-ab27-23cf652dfcef.MP4

https://user-images.githubusercontent.com/86882798/199260460-991e0c97-c1b7-47ef-8da0-e079bdd564de.MP4|

