### PR TITLE
[Fix] #89 기기별로 매칭된 음악 셀의 Gradient 가 다르게 적용되는 버그를 해결하였습니다.

### DIFF
--- a/PLREQ/PLREQ/Extensions/UIImageView+.swift
+++ b/PLREQ/PLREQ/Extensions/UIImageView+.swift
@@ -28,14 +28,14 @@ extension UIImageView {
     }
     
     // MatchMusicCell Image Gradient
-    func addMusicCellGradient(imageView: UIImageView) {
+    func addMusicCellGradient(imageView: UIImageView, cell: UICollectionViewCell) {
         guard imageView.layer.sublayers?.count != 1 else { return }
         let gradient: CAGradientLayer = CAGradientLayer()
         gradient.colors = [UIColor.clear.cgColor, UIColor(red: 0, green: 0, blue: 0, alpha: 0.5).cgColor]
         gradient.locations = [0.0 , 1.0]
         gradient.startPoint = CGPoint(x: 0.0, y: 0.0)
         gradient.endPoint = CGPoint(x: 0.0, y: 1.0)
-        gradient.frame = bounds
+        gradient.frame = cell.bounds
         layer.addSublayer(gradient)
     }
     

--- a/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
+++ b/PLREQ/PLREQ/Views/MatchView/MatchViewController.swift
@@ -276,7 +276,7 @@ extension MatchViewController: UICollectionViewDataSource {
                 cell.musicImage.image = UIImage(data: data!)
             }
         }
-        cell.musicImage.addMusicCellGradient(imageView: cell.musicImage)
+        cell.musicImage.addMusicCellGradient(imageView: cell.musicImage, cell: cell)
         return cell
     }
 }


### PR DESCRIPTION
@LeeSungNo-ian  
@yeniful 
@Juhwa-Lee1023 

---
안녕하세요! @yeniful 께서 찾아주신 기기별로 매칭된 음악 셀의 Gradient 가 다르게 적용되는 버그를 해결하였습니다. 버그를 찾아주셔서 감사합니다!

---

### OutLine
- #89 

### Work Contents
- 기기별로 매칭된 음악의 gradient 가 다르게 적용되는 버그를 해결하였습니다.

### App Action Screen
|IPhone14|IPhone14Pro Max|
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2022-11-04 at 00 45 04](https://user-images.githubusercontent.com/86882798/199768407-956f2dcc-d00d-4235-8593-a91a7700dcc5.png)|![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-04 at 00 45 16](https://user-images.githubusercontent.com/86882798/199768443-4887ee83-499c-425c-b375-aa359fb108d6.png)|